### PR TITLE
Support for additional fields in GELF messages

### DIFF
--- a/graypy/handler.py
+++ b/graypy/handler.py
@@ -57,6 +57,21 @@ class GELFHandler(DatagramHandler):
         # record.processName was added in Python 2.6.2
         if hasattr(record, 'processName'):
             d['_process_name'] = record.processName
+
+        # Add any additional fields. skipList contains all attributes listed in
+        # http://docs.python.org/library/logging.html#logrecord-attributes
+        # plus the exc_text, which is only found in the logging module source.
+        skipList = ['args', 'asctime', 'created', 'exc_info',  'exc_text',
+            'filename', 'funcName', 'levelname', 'levelno', 'lineno',
+            'module', 'msecs', 'msecs', 'message', 'msg', 'name', 'pathname',
+            'process', 'processName', 'relativeCreated', 'thread', 'threadName']
+
+        for key in record.__dict__:
+            if key in skipList:
+                continue
+
+            d['_' + key] = record.__dict__[key]
+
         return d
 
 


### PR DESCRIPTION
Additional fields in a log message are prefixed with an
underscore (see GELF format[1]) and send to the graylog2
server together with the other fields.

See [2] for information on adding extra fields to your
log messages in Python.

[1] https://github.com/Graylog2/graylog2-docs/wiki/GELF
[2] http://docs.python.org/howto/logging-cookbook.html#adding-contextual-information-to-your-logging-output
