### PR TITLE
Chunked messages for GELF 1.0

### DIFF
--- a/graypy/handler.py
+++ b/graypy/handler.py
@@ -83,8 +83,8 @@ class ChunkedGELF(object):
     def __init__(self, message, size):
         self.message = message
         self.size = size
-        self.pieces = struct.pack('>H', (len(message) / size) + 1)
-        self.id = struct.pack('Q', random.randint(0, 0xFFFFFFFFFFFFFFFF)) * 4
+        self.pieces = struct.pack('B', (len(message) / size) + 1)
+        self.id = struct.pack('Q', random.randint(0, 0xFFFFFFFFFFFFFFFF))
 
     def message_chunks(self):
         return (self.message[i:i+self.size] for i
@@ -94,7 +94,7 @@ class ChunkedGELF(object):
         return ''.join([
             '\x1e\x0f',
             self.id,
-            struct.pack('>H', sequence),
+            struct.pack('B', sequence),
             self.pieces,
             chunk
         ])


### PR DESCRIPTION
Somehow my Graylog2 server didn't want to accept chunked messages with the error message `Invalid GELF header in message: Could not extract sequence number`.

A little bid of digging revealed, that that message headers aren't set according to the most current specification I could find: https://github.com/Graylog2/graylog2-docs/wiki/GELF

After changing the sequence length and sequence numbers to single bytes and the message ID to 8 bytes the server accepts the mesages again.
