### PR TITLE
Wrong number of pieces when message length is a multiple of size

### DIFF
--- a/graypy/handler.py
+++ b/graypy/handler.py
@@ -5,6 +5,7 @@ import traceback
 import struct
 import random
 import socket
+import math
 from logging.handlers import DatagramHandler
 
 
@@ -49,7 +50,7 @@ class ChunkedGELF(object):
     def __init__(self, message, size):
         self.message = message
         self.size = size
-        self.pieces = struct.pack('B', (len(message) / size) + 1)
+        self.pieces = struct.pack('B', int(math.ceil(len(message) * 1.0/size)))
         self.id = struct.pack('Q', random.randint(0, 0xFFFFFFFFFFFFFFFF))
 
     def message_chunks(self):


### PR DESCRIPTION
Hi.

The number of pieces is off by one when the message length is exactly a multiple of size.

For example, assuming `size = 3` and `message="foobar"`, then `(len(message) / size) + 1 == 3`, when we want 2.
