### PR TITLE
GELFRabbitHandler.makePickle() uses make_message_dict as well. Fix it up.

### DIFF
--- a/graypy/rabbitmq.py
+++ b/graypy/rabbitmq.py
@@ -24,7 +24,7 @@ class GELFRabbitHandler(SocketHandler):
     """
 
     def __init__(self, url, exchange='logging.gelf', debugging_fields=True,
-            extra_fields=True, fqdn=False, exchange_type='fanout'):
+            extra_fields=True, fqdn=False, exchange_type='fanout', localname=None):
         self.url = url
         parsed = urlparse(url)
         if parsed.scheme != 'amqp':
@@ -43,6 +43,7 @@ class GELFRabbitHandler(SocketHandler):
         self.extra_fields = extra_fields
         self.fqdn = fqdn
         self.exchange_type = exchange_type
+        self.localname = localname
         SocketHandler.__init__(self, host, port)
         self.addFilter(ExcludeFilter('amqplib'))
 
@@ -52,7 +53,7 @@ class GELFRabbitHandler(SocketHandler):
 
     def makePickle(self, record):
         message_dict = make_message_dict(
-            record, self.debugging_fields, self.extra_fields, self.fqdn)
+            record, self.debugging_fields, self.extra_fields, self.fqdn, self.localname)
         return json.dumps(message_dict)
 
 


### PR DESCRIPTION
GELFRabbitHandler.makePickle() uses make_message_dict as well.
Fix it up.

Signed-off-by: Brian Jackson iggy@theiggy.com
