### PR TITLE
Make facility configurable

### DIFF
--- a/graypy/rabbitmq.py
+++ b/graypy/rabbitmq.py
@@ -24,7 +24,8 @@ class GELFRabbitHandler(SocketHandler):
     """
 
     def __init__(self, url, exchange='logging.gelf', debugging_fields=True,
-            extra_fields=True, fqdn=False, exchange_type='fanout', localname=None):
+            extra_fields=True, fqdn=False, exchange_type='fanout', localname=None,
+            facility=None):
         self.url = url
         parsed = urlparse(url)
         if parsed.scheme != 'amqp':
@@ -44,6 +45,7 @@ class GELFRabbitHandler(SocketHandler):
         self.fqdn = fqdn
         self.exchange_type = exchange_type
         self.localname = localname
+        self.facility = facility
         SocketHandler.__init__(self, host, port)
         self.addFilter(ExcludeFilter('amqplib'))
 
@@ -53,7 +55,8 @@ class GELFRabbitHandler(SocketHandler):
 
     def makePickle(self, record):
         message_dict = make_message_dict(
-            record, self.debugging_fields, self.extra_fields, self.fqdn, self.localname)
+            record, self.debugging_fields, self.extra_fields, self.fqdn, self.localname,
+            self.facility)
         return json.dumps(message_dict)
 
 


### PR DESCRIPTION
Hi,

after using graypy for some time we get a bit annoyed that every system using graylog use application name for facility but our django processes use logger name. It's hard to read and what's more important, hard to filter logs for specific django application.

What works for us is setting facility to application name and then send record.name as additional "logger" field.

Also it's compliant with unix/syslog way of doing things (The facility argument is used to specify what type of program is logging the message), so ops/support would also appreciate this change :)

Proposed change is backwards compatible, so if possible, please pull it to master, so we can use official package back again.

Piotr 
