### PR TITLE
Refactored, added support for custom-fields dictionary

### DIFF
--- a/graypy/handler.py
+++ b/graypy/handler.py
@@ -7,7 +7,6 @@ import random
 import socket
 import math
 from logging.handlers import DatagramHandler
-import sys
 
 WAN_CHUNK, LAN_CHUNK = 1420, 8154
 FULL_MESSAGE_KEYS = ("FULLMESSAGE", "FULL_MESSAGE", "MESSAGE")


### PR DESCRIPTION
- Refactored hostname lookup so it's only called once on startup and not everytime a message is logged
- Added support to log a custom dictionary as additional fields:  

``` python
logger.debug({
   "Type": "Request",
   "User": "Joe",
   "Message": "GET /my/url"
})
```

Sends this GELF message:  

``` json
{
   ...
   "full_message": "GET /my/url",
   "_Type": "Request",
   "_User": "Joe"
}
```
