### PR TITLE
makePickle calls the formatter before compression

### DIFF
--- a/graypy/handler.py
+++ b/graypy/handler.py
@@ -49,6 +49,7 @@ class GELFHandler(DatagramHandler):
                 DatagramHandler.send(self, chunk)
 
     def makePickle(self, record):
+        record.msg = self.format(record)
         message_dict = make_message_dict(
             record, self.debugging_fields, self.extra_fields, self.fqdn, 
 	    self.localname, self.facility)


### PR DESCRIPTION
I am creating streams in Graylog using regexes by parsing a token at the begging of the message, which is added via a simple formatter.

After a close look at the python logging library source code, my conclusion is that  DatagramHandler doesn't use formatters cause it is extends from SocketHandler and overrides it's makePickle without calling format like its super. I assume DatagramHandler is meant for low level use cases where formatting is not needed (?), or maybe because of serializing problems.

In any case, there is no reason, as far as I know, why Graylog couldn't receive formatted messages, and thus I've added it to makePickle again.

Cheers.