### PR TITLE
Don't call repr() on string objects for extra_fields

### DIFF
--- a/graypy/handler.py
+++ b/graypy/handler.py
@@ -144,6 +144,9 @@ def add_extra_fields(message_dict, record):
 
     for key, value in record.__dict__.items():
         if key not in skip_list and not key.startswith('_'):
-            message_dict['_%s' % key] = repr(value)
+            if isinstance(value, basestring):
+                message_dict['_%s' % key] = value
+            else:
+                message_dict['_%s' % key] = repr(value)
 
     return message_dict


### PR DESCRIPTION
When adding static contextual information to log records to filter on in the graylog2 interface, `extra_fields` (e.g., those added via a Python `logging.Filter`) will be strings.  The fact that `repr()` adds quotes around these strings is problematic for the graylog2 interface because (1) none of the other (non-`extra_fields`) strings have quotes around them, and (2) when you click on one of the quoted fields to filter on it, the filter doesn't work until you manually remove the quotes in the web interface.

This pull request includes string-based `extra_fields` directly rather than calling `repr()`, and leaves the behavior unchanged for all other object types.
