### PR TITLE
Logger field should be additional field

### DIFF
--- a/graypy/handler.py
+++ b/graypy/handler.py
@@ -98,7 +98,7 @@ def make_message_dict(record, debugging_fields, extra_fields, fqdn, localname, f
 
     if facility is not None:
         fields.update({
-            'logger': record.name
+            '_logger': record.name
         })
 
     if debugging_fields:


### PR DESCRIPTION
According to GELF specification, logger field is not in the default GELF list, therefore should be prefixed with an underscore to explicitly mark it as additional field. This allows the field to appear in the graylog2 web interface as well.
