### PR TITLE
Sanitize values in message_dict before serializing to json

### DIFF
--- a/graypy/handler.py
+++ b/graypy/handler.py
@@ -23,7 +23,7 @@ class GELFHandler(DatagramHandler):
     :param debugging_fields: Send debug fields if true (the default).
     :param extra_fields: Send extra fields on the log record to graylog
         if true (the default).
-    :param fqdn: Use fully qualified domain name of localhost as source 
+    :param fqdn: Use fully qualified domain name of localhost as source
         host (socket.getfqdn()).
     :param localname: Use specified hostname as source host.
     :param facility: Replace facility with specified value. If specified,
@@ -31,7 +31,7 @@ class GELFHandler(DatagramHandler):
     """
 
     def __init__(self, host, port=12201, chunk_size=WAN_CHUNK,
-            debugging_fields=True, extra_fields=True, fqdn=False, 
+            debugging_fields=True, extra_fields=True, fqdn=False,
             localname=None, facility=None):
         self.debugging_fields = debugging_fields
         self.extra_fields = extra_fields
@@ -50,8 +50,17 @@ class GELFHandler(DatagramHandler):
 
     def makePickle(self, record):
         message_dict = make_message_dict(
-            record, self.debugging_fields, self.extra_fields, self.fqdn, 
+            record, self.debugging_fields, self.extra_fields, self.fqdn,
 	    self.localname, self.facility)
+        for key, value in message_dict.items():
+            try:
+                json.dumps(value)
+            except ValueError:
+                if (isinstance(value, basestring)
+                        and not isinstance(value, unicode)):
+                    message_dict[key] = repr(value)[1:-1]
+                else:
+                    message_dict[key] = repr(value)
         return zlib.compress(json.dumps(message_dict))
 
 

--- a/test/gelf_datagram_test.py
+++ b/test/gelf_datagram_test.py
@@ -1,0 +1,88 @@
+import json
+import logging
+import unittest
+import zlib
+
+import mock
+
+from graypy.handler import GELFHandler
+
+
+class GELFHandlerTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.handler = GELFHandler('some.host')
+        self.logger = logging.getLogger('test')
+        self.logger.addHandler(self.handler)
+
+    def test_normal(self):
+        with mock.patch.object(self.handler, 'send') as mock_send:
+            self.logger.error('Normal log message')
+            [[[arg], _]] = mock_send.call_args_list
+        decoded = json.loads(zlib.decompress(arg))
+        self.assertEqual(decoded['short_message'], decoded['full_message'])
+        self.assertEqual(decoded['short_message'], 'Normal log message')
+
+    def test_normal_exception_handler(self):
+        with mock.patch.object(self.handler, 'send') as mock_send:
+            try:
+                raise SyntaxError('Syntax error')
+            except Exception:
+                self.logger.exception('Failed')
+            [[[arg], _]] = mock_send.call_args_list
+        decoded = json.loads(zlib.decompress(arg))
+        self.assertEqual(decoded['short_message'], 'Failed')
+        self.assertTrue(decoded['full_message'].startswith(
+            'Traceback (most recent call last):'))
+        self.assertTrue(decoded['full_message'].endswith(
+            'SyntaxError: Syntax error\n'))
+
+    def test_unicode(self):
+        with mock.patch.object(self.handler, 'send') as mock_send:
+            self.logger.error(u'Mensaje de registro espa\xf1ol')
+            [[[arg], _]] = mock_send.call_args_list
+        decoded = json.loads(zlib.decompress(arg))
+        self.assertEqual(decoded['short_message'], decoded['full_message'])
+        self.assertEqual(decoded['short_message'],
+                         u'Mensaje de registro espa\xf1ol')
+
+    def test_unicode_exception_handler(self):
+        with mock.patch.object(self.handler, 'send') as mock_send:
+            try:
+                raise SyntaxError('S\xc2\xa5nt4x 3r\xc2\xae0r')
+            except Exception:
+                self.logger.exception(u'une d\xc3\xa9faillance')
+            [[[arg], _]] = mock_send.call_args_list
+        decoded = json.loads(zlib.decompress(arg))
+        self.assertEqual(decoded['short_message'], u'une d\xc3\xa9faillance')
+        self.assertTrue(decoded['full_message'].startswith(
+            u'Traceback (most recent call last):'))
+        self.assertTrue(decoded['full_message'].endswith(
+            u'SyntaxError: S\xa5nt4x 3r\xae0r\n'))
+
+    def test_broken(self):
+        with mock.patch.object(self.handler, 'send') as mock_send:
+            self.logger.error('Broken \xde log message')
+            [[[arg], _]] = mock_send.call_args_list
+        decoded = json.loads(zlib.decompress(arg))
+        self.assertEqual(decoded['short_message'], decoded['full_message'])
+        self.assertEqual(decoded['short_message'],
+                         r'Broken \xde log message')
+
+    def test_broken_exception_handler(self):
+        with mock.patch.object(self.handler, 'send') as mock_send:
+            try:
+                raise SyntaxError('Syntax \xde error')
+            except Exception:
+                self.logger.exception('Failed')
+            [[[arg], _]] = mock_send.call_args_list
+        decoded = json.loads(zlib.decompress(arg))
+        self.assertEqual(decoded['short_message'], 'Failed')
+        self.assertTrue(decoded['full_message'].startswith(
+            'Traceback (most recent call last):'))
+        # XXX: the newline here should really be unescaped
+        self.assertTrue(decoded['full_message'].endswith(
+            'Syntax \\xde error\\n'))
+
+    def tearDown(self):
+        self.logger.removeHandler(self.handler)


### PR DESCRIPTION
If one attempts to log a message, that is a bytestring containing invalid utf-8, json.dumps in makePickle raises UnicodeDecodeError. This pull request attempts to fix this by sanitizing offending values in message_dict using repr. While attempting to log raw byte sequences is not particularly a good idea, a logging library by any means should not just error out, it should make the best effort to log the message, whatever it contains (that is the behaviour of loggers / handlers in the standard library).

Tests, demonstrating erroneous behaviour are also included.
