### PR TITLE
make handler Py3 compatible

### DIFF
--- a/graypy/__init__.py
+++ b/graypy/__init__.py
@@ -1,5 +1,5 @@
 from graypy.handler import GELFHandler, WAN_CHUNK, LAN_CHUNK
 try:
-    from rabbitmq import GELFRabbitHandler, ExcludeFilter
+    from graypy.rabbitmq import GELFRabbitHandler, ExcludeFilter
 except ImportError:
     pass # amqplib is probably not installed

--- a/graypy/handler.py
+++ b/graypy/handler.py
@@ -17,8 +17,10 @@ PY3 = sys.version_info[0] == 3
 
 if PY3:
     string_type = str
+    integer_type = int,
 else:
     string_type = basestring
+    integer_type = (int, long)
 
 
 class GELFHandler(DatagramHandler):
@@ -76,8 +78,8 @@ class ChunkedGELF(object):
                     in range(0, len(self.message), self.size))
 
     def encode(self, sequence, chunk):
-        return ''.join([
-            '\x1e\x0f',
+        return b''.join([
+            b'\x1e\x0f',
             self.id,
             struct.pack('B', sequence),
             self.pieces,
@@ -153,7 +155,7 @@ def add_extra_fields(message_dict, record):
 
     for key, value in record.__dict__.items():
         if key not in skip_list and not key.startswith('_'):
-            if isinstance(value, (string_type, int, long, float)):
+            if isinstance(value, (string_type, float) + integer_type):
                 message_dict['_%s' % key] = value
             else:
                 message_dict['_%s' % key] = repr(value)

--- a/graypy/rabbitmq.py
+++ b/graypy/rabbitmq.py
@@ -3,8 +3,12 @@ from amqplib import client_0_8 as amqp
 from graypy.handler import make_message_dict
 from logging import Filter
 from logging.handlers import SocketHandler
-from urlparse import urlparse
-import urllib
+
+try:
+    from urllib.parse import urlparse, unquote
+except ImportError:
+    from urlparse import urlparse
+    from urllib import unquote
 
 
 _ifnone = lambda v, x: x if v is None else v
@@ -39,7 +43,7 @@ class GELFRabbitHandler(SocketHandler):
             raise ValueError('invalid URL scheme (expected "amqp"): %s' % url)
         host = parsed.hostname or 'localhost'
         port = _ifnone(parsed.port, 5672)
-        virtual_host = virtual_host if not urllib.unquote(parsed.path[1:]) else urllib.unquote(parsed.path[1:])
+        virtual_host = virtual_host if not unquote(parsed.path[1:]) else unquote(parsed.path[1:])
         self.cn_args = {
             'host': '%s:%s' % (host, port),
             'userid': _ifnone(parsed.username, 'guest'),

--- a/perftest.py
+++ b/perftest.py
@@ -11,6 +11,8 @@ def main(argv=sys.argv):
         help='Graylog2 host. Do not test GELFHandler if not specified.')
     parser.add_argument('--graylog-port', type=int, default=12201,
         help='Graylog2 GELF UDP port. Default: 12201')
+    parser.add_argument('--graylog-chunked', action='store_true', default=None,
+        help='Test graylog with chunked messages')
     parser.add_argument('--rabbit-url',
         help='RabbitMQ url (ex: amqp://guest:guest@localhost/). '
              'Do not test GELFRabbitHandler if not specified.')
@@ -44,6 +46,9 @@ def main(argv=sys.argv):
             'debugging_fields': 0,
             'formatter': 'message',
         }
+        if args.graylog_chunked:
+            config['handlers']['graylog_udp']['chunk_size'] = 1
+
         config['root']['handlers'].append('graylog_udp')
 
     if args.rabbit_url is not None:


### PR DESCRIPTION
I've used some code from six to make handler working OK with Py3 + extra fields.

Currently when we log something with extra fields, it crash because `basestring` is not part of Python 3. 
