### PR TITLE
datetime serialization

### DIFF
--- a/graypy/handler.py
+++ b/graypy/handler.py
@@ -1,3 +1,4 @@
+import datetime
 import sys
 import logging
 import json
@@ -29,7 +30,7 @@ class GELFHandler(DatagramHandler):
     :param debugging_fields: Send debug fields if true (the default).
     :param extra_fields: Send extra fields on the log record to graylog
         if true (the default).
-    :param fqdn: Use fully qualified domain name of localhost as source 
+    :param fqdn: Use fully qualified domain name of localhost as source
         host (socket.getfqdn()).
     :param localname: Use specified hostname as source host.
     :param facility: Replace facility with specified value. If specified,
@@ -37,7 +38,7 @@ class GELFHandler(DatagramHandler):
     """
 
     def __init__(self, host, port=12201, chunk_size=WAN_CHUNK,
-            debugging_fields=True, extra_fields=True, fqdn=False, 
+            debugging_fields=True, extra_fields=True, fqdn=False,
             localname=None, facility=None):
         self.debugging_fields = debugging_fields
         self.extra_fields = extra_fields
@@ -154,10 +155,17 @@ def add_extra_fields(message_dict, record):
     return message_dict
 
 
+def smarter_repr(obj):
+    """ convert JSON incompatible object to string"""
+    if isinstance(obj, datetime.datetime):
+        return obj.isoformat()
+    return repr(obj)
+
+
 def message_to_pickle(obj):
     """ convert object to a JSON-encoded string"""
     obj = sanitize(obj)
-    serialized = json.dumps(obj, separators=',:', default=repr)
+    serialized = json.dumps(obj, separators=',:', default=smarter_repr)
     return serialized.encode('utf-8')
 
 

--- a/tests/test_gelf_datagram.py
+++ b/tests/test_gelf_datagram.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import datetime
 import json
 import logging
 import pytest
@@ -101,3 +102,12 @@ def test_list(logger, mock_send):
     logger.error('Log message', extra={'foo': ['bar', 'baz']})
     decoded = get_mock_send_arg(mock_send)
     assert decoded['_foo'] == ['bar', 'baz']
+
+
+def test_message_to_pickle_serializes_datetime_objects_instead_of_blindly_repring_them(logger, mock_send):
+    timestamp = datetime.datetime(2001, 2, 3, 4, 5, 6, 7)
+    logger.error('Log message', extra={'ts': timestamp})
+    decoded = get_mock_send_arg(mock_send)
+
+    assert 'datetime.datetime' not in decoded['_ts']
+    assert decoded['_ts'] == timestamp.isoformat()


### PR DESCRIPTION
Hello,

Currently, `datetime.datetime` objects are serialized with a `repr` call, which generates output like `"datetime.datetime(2015, 12, 17, 11, 20, 43, 137)"`. This is not a very nice output, harder tu use in graylog searches etc.

I think, most people would naturally expect to see `datetime.datetime` objects converted to strings with a `datetime.datetime.isoformat` call.
