### PR TITLE
Feature/dynamic version number

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,6 +67,7 @@ GELFHandler:
   * **fqdn** - use fully qualified domain name of localhost as source host (socket.getfqdn()).
   * **localname** - use specified hostname as source host.
   * **facility** - replace facility with specified value. if specified, record.name will be passed as *logger* parameter.
+  * **version** - replace version with your project's number.  Defaults to "1.0".
 
 GELFRabbitHandler:
 
@@ -78,6 +79,7 @@ GELFRabbitHandler:
   * **exchange_type** - RabbitMQ exchange type (default `fanout`).
   * **localname** - use specified hostname as source host.
   * **facility** - replace facility with specified value. if specified, record.name will be passed as `logger` parameter.
+  * **version** - replace version with your project's number.  Defaults to "1.0".
 
 Using with Django
 =================

--- a/graypy/handler.py
+++ b/graypy/handler.py
@@ -39,7 +39,7 @@ class GELFHandler(DatagramHandler):
 
     def __init__(self, host, port=12201, chunk_size=WAN_CHUNK,
             debugging_fields=True, extra_fields=True, fqdn=False,
-            localname=None, facility=None, version="1.0"):
+            localname=None, facility=None, version='1.0'):
         self.debugging_fields = debugging_fields
         self.extra_fields = extra_fields
         self.chunk_size = chunk_size

--- a/graypy/handler.py
+++ b/graypy/handler.py
@@ -39,13 +39,14 @@ class GELFHandler(DatagramHandler):
 
     def __init__(self, host, port=12201, chunk_size=WAN_CHUNK,
             debugging_fields=True, extra_fields=True, fqdn=False,
-            localname=None, facility=None):
+            localname=None, facility=None, version="1.0"):
         self.debugging_fields = debugging_fields
         self.extra_fields = extra_fields
         self.chunk_size = chunk_size
         self.fqdn = fqdn
         self.localname = localname
         self.facility = facility
+        self.version = version
         DatagramHandler.__init__(self, host, port)
 
     def send(self, s):
@@ -58,7 +59,7 @@ class GELFHandler(DatagramHandler):
     def makePickle(self, record):
         message_dict = make_message_dict(
             record, self.debugging_fields, self.extra_fields, self.fqdn,
-            self.localname, self.facility)
+            self.localname, self.version, self.facility)
         return zlib.compress(message_to_pickle(message_dict))
 
 
@@ -87,14 +88,14 @@ class ChunkedGELF(object):
             yield self.encode(sequence, chunk)
 
 
-def make_message_dict(record, debugging_fields, extra_fields, fqdn, localname, facility=None):
+def make_message_dict(record, debugging_fields, extra_fields, fqdn, localname, version, facility=None):
     if fqdn:
         host = socket.getfqdn()
     elif localname:
         host = localname
     else:
         host = socket.gethostname()
-    fields = {'version': "1.0",
+    fields = {'version': version,
         'host': host,
         'short_message': record.getMessage(),
         'full_message': get_full_message(record.exc_info, record.getMessage()),

--- a/graypy/rabbitmq.py
+++ b/graypy/rabbitmq.py
@@ -26,7 +26,7 @@ class GELFRabbitHandler(SocketHandler):
     :param debugging_fields: Send debug fields if true (the default).
     :param extra_fields: Send extra fields on the log record to graylog
         if true (the default).
-    :param fqdn: Use fully qualified domain name of localhost as source 
+    :param fqdn: Use fully qualified domain name of localhost as source
         host (socket.getfqdn()).
     :param exchange_type: RabbitMQ exchange type (default 'fanout').
     :param localname: Use specified hostname as source host.
@@ -36,7 +36,7 @@ class GELFRabbitHandler(SocketHandler):
 
     def __init__(self, url, exchange='logging.gelf', debugging_fields=True,
             extra_fields=True, fqdn=False, exchange_type='fanout', localname=None,
-            facility=None, virtual_host='/'):
+            facility=None, virtual_host='/', version='1.0'):
         self.url = url
         parsed = urlparse(url)
         if parsed.scheme != 'amqp':
@@ -58,6 +58,7 @@ class GELFRabbitHandler(SocketHandler):
         self.exchange_type = exchange_type
         self.localname = localname
         self.facility = facility
+        self.version = version
         self.virtual_host = virtual_host
         SocketHandler.__init__(self, host, port)
         self.addFilter(ExcludeFilter('amqplib'))
@@ -69,7 +70,7 @@ class GELFRabbitHandler(SocketHandler):
     def makePickle(self, record):
         message_dict = make_message_dict(
             record, self.debugging_fields, self.extra_fields, self.fqdn, self.localname,
-            self.facility)
+            self.version, self.facility)
         return json.dumps(message_dict)
 
 


### PR DESCRIPTION
This feature allows for users to change the version number at instantiation time.  I was unable to override the version number using Filters or Adapters.  This solution allows users to override the version number very easily.  Before this change, the version is hardcoded and difficult to override unless I am missing something.  I made the default value still be "1.0" as you had previously.
