### PR TITLE
Add GELF TCP handler and disable compression by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist/
 graypy.egg-info/
 *.pyc
 .tox
+.idea

--- a/graypy/__init__.py
+++ b/graypy/__init__.py
@@ -1,4 +1,4 @@
-from graypy.handler import GELFHandler, WAN_CHUNK, LAN_CHUNK
+from graypy.handler import GELFHandler, GELFTcpHandler, WAN_CHUNK, LAN_CHUNK
 try:
     from graypy.rabbitmq import GELFRabbitHandler, ExcludeFilter
 except ImportError:

--- a/graypy/handler.py
+++ b/graypy/handler.py
@@ -8,7 +8,7 @@ import struct
 import random
 import socket
 import math
-from logging.handlers import DatagramHandler
+from logging.handlers import DatagramHandler, SocketHandler
 
 PY3 = sys.version_info[0] == 3
 WAN_CHUNK, LAN_CHUNK = 1420, 8154
@@ -37,11 +37,12 @@ class GELFHandler(DatagramHandler):
         record.name will be passed as `logger` parameter.
     :param level_names: Allows the use of string error level names instead
         of numerical values. Defaults to False
+    :param compress: Allows to use message compression. Defaults to False
     """
 
     def __init__(self, host, port=12201, chunk_size=WAN_CHUNK,
             debugging_fields=True, extra_fields=True, fqdn=False,
-            localname=None, facility=None, level_names=False):
+            localname=None, facility=None, level_names=False, compress=False):
         self.debugging_fields = debugging_fields
         self.extra_fields = extra_fields
         self.chunk_size = chunk_size
@@ -49,6 +50,7 @@ class GELFHandler(DatagramHandler):
         self.localname = localname
         self.facility = facility
         self.level_names = level_names
+        self.compress = compress
         DatagramHandler.__init__(self, host, port)
 
     def send(self, s):
@@ -62,7 +64,49 @@ class GELFHandler(DatagramHandler):
         message_dict = make_message_dict(
             record, self.debugging_fields, self.extra_fields, self.fqdn,
             self.localname, self.level_names, self.facility)
-        return zlib.compress(message_to_pickle(message_dict))
+        packed = message_to_pickle(message_dict)
+        frame = zlib.compress(packed) if self.compress else packed
+        return frame
+
+
+class GELFTcpHandler(SocketHandler):
+    """Graylog Extended Log Format handler over TCP
+
+    :param host: The host of the graylog server.
+    :param port: The port of the graylog server (default 12201).
+    :param debugging_fields: Send debug fields if true (the default).
+    :param extra_fields: Send extra fields on the log record to graylog
+        if true (the default).
+    :param fqdn: Use fully qualified domain name of localhost as source
+        host (socket.getfqdn()).
+    :param localname: Use specified hostname as source host.
+    :param facility: Replace facility with specified value. If specified,
+        record.name will be passed as `logger` parameter.
+    :param level_names: Allows the use of string error level names instead
+        of numerical values. Defaults to False
+    :param compress: Allows to use message compression. Defaults to False
+    """
+
+    def __init__(self, host, port=12201,
+                 debugging_fields=True, extra_fields=True, fqdn=False,
+                 localname=None, facility=None, level_names=False, compress=False):
+        self.debugging_fields = debugging_fields
+        self.extra_fields = extra_fields
+        self.fqdn = fqdn
+        self.localname = localname
+        self.facility = facility
+        self.level_names = level_names
+        self.compress = compress
+        SocketHandler.__init__(self, host, port)
+
+    def makePickle(self, record):
+        message_dict = make_message_dict(
+            record, self.debugging_fields, self.extra_fields, self.fqdn,
+            self.localname, self.level_names, self.facility)
+        # if you send the message over tcp, it should always be null terminated or the input will reject it
+        packed = message_to_pickle(message_dict)
+        frame = zlib.compress(packed) if self.compress else packed
+        return frame + b'\x00'
 
 
 class ChunkedGELF(object):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 setup(
 
     name='graypy',
-    version='0.2.13',
+    version='0.2.13.2',
     description="Python logging handler that sends messages in GELF (Graylog Extended Log Format).",
     long_description=open('README.rst').read(),
     keywords='logging gelf graylog2 graylog udp amqp',


### PR DESCRIPTION
Allows to use TCP handler for reliable logs delivery

Also disabling compression by default to allow use proxy like https://github.com/jedisct1/flowgger
