### PR TITLE
Add the ability to set port as string

### DIFF
--- a/graypy/handler.py
+++ b/graypy/handler.py
@@ -51,7 +51,7 @@ class GELFHandler(DatagramHandler):
         self.facility = facility
         self.level_names = level_names
         self.compress = compress
-        DatagramHandler.__init__(self, host, port)
+        DatagramHandler.__init__(self, host, int(port))
 
     def send(self, s):
         if len(s) < self.chunk_size:


### PR DESCRIPTION
It is convenient to initialize the handler like GELFHandler(*sys.argv[1].split(":")) - so that the port comes in a string type.