### PR TITLE
Fix GELFRabbitHandler example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Alternately, use ``GELFRabbitHandler`` to send messages to RabbitMQ and configur
     my_logger = logging.getLogger('test_logger')
     my_logger.setLevel(logging.DEBUG)
 
-    handler = graypy.GELFRabbitHandler('amqp://guest:guest@localhost/%2F', 'logging.gelf')
+    handler = graypy.GELFRabbitHandler('amqp://guest:guest@localhost/', exchange='logging.gelf')
     my_logger.addHandler(handler)
 
     my_logger.debug('Hello Graylog2.')


### PR DESCRIPTION
The `%2F` in the string must be a legacy approach.  If the string includes `%2F`, the vhost always ends up as `/`, ignoring the `virtual_host` kwarg.  I also made the `exchange` into an explicit kwarg.  It duplicates the default so it could actually be excluded, but making it explicit helps the user realize where the messages are found.