### PR TITLE
Check exc_text in addition to exc_info for exception information.

### DIFF
--- a/graypy/handler.py
+++ b/graypy/handler.py
@@ -105,7 +105,7 @@ def make_message_dict(record, debugging_fields, extra_fields, fqdn, localname,
     fields = {'version': "1.0",
         'host': host,
         'short_message': record.getMessage(),
-        'full_message': get_full_message(record.exc_info, record.getMessage()),
+        'full_message': get_full_message(record),
         'timestamp': record.created,
         'level': SYSLOG_LEVELS.get(record.levelno, record.levelno),
         'facility': facility or record.name,
@@ -144,8 +144,15 @@ SYSLOG_LEVELS = {
 }
 
 
-def get_full_message(exc_info, message):
-    return '\n'.join(traceback.format_exception(*exc_info)) if exc_info else message
+def get_full_message(record):
+    # format exception information if present
+    if record.exc_info:
+      return '\n'.join(traceback.format_exception(*record.exc_info))
+    # use pre-formatted exception information in cases where the primary
+    # exception information was removed, eg. for LogRecord serialization
+    if record.exc_text:
+      return record.exc_text
+    return record.getMessage()
 
 
 def add_extra_fields(message_dict, record):


### PR DESCRIPTION
The exc_info field may have been stripped for LogRecord serialization. If this is done via a Formatter then formatted exception information may be available in exc_text, cf. https://docs.python.org/3.6/library/logging.html#formatter-objects

Serialization happens for example if the LogRecord is passed through a QueueHandler or a SocketHandler before being passed to graypy. https://docs.python.org/3.6/library/logging.handlers.html#module-logging.handlers