### PR TITLE
Async GELF Handler

### DIFF
--- a/graypy/async_handler.py
+++ b/graypy/async_handler.py
@@ -1,4 +1,6 @@
 from Queue import Queue
+
+import traceback
 from graypy import GELFHandler
 from threading import Thread
 
@@ -25,5 +27,8 @@ class AsyncGELFHandler(GELFHandler, Thread):
                 record = self.output_queue.get()
                 self._process_queue_record(record)
                 self.output_queue.task_done()
+
             except Exception as ex:
-                pass
+                # Handle log sending exception in some way. eg. traceback.print_exc():
+                # Exception handling is mandatory, otherwise the thread will die
+                traceback.print_exc()

--- a/graypy/async_handler.py
+++ b/graypy/async_handler.py
@@ -1,0 +1,29 @@
+from Queue import Queue
+from graypy import GELFHandler
+from threading import Thread
+
+
+class AsyncGELFHandler(GELFHandler, Thread):
+    def __init__(self, *args, **kwargs):
+        super(AsyncGELFHandler, self).__init__(*args, **kwargs)
+        Thread.__init__(self)
+        self.output_queue = Queue()
+
+        # Start thread
+        self.start()
+
+    def send(self, s):
+        self.output_queue.put(s)
+
+    def _process_queue_record(self, s):
+        super(AsyncGELFHandler, self).send(s)
+
+    def run(self):
+
+        while True:
+            try:
+                record = self.output_queue.get()
+                self._process_queue_record(record)
+                self.output_queue.task_done()
+            except Exception as ex:
+                pass


### PR DESCRIPTION
I simply inherited GELFHandler to obtain an aynchronous logging handler class.

That's mandatory to achieve non-blocking logging features when DNS resolution fails or timeout (eg. due to internet connection unavailability), blocking the logging.log function until the resolution timeout, even when using UDP GELF Protocol.

It starts a background consumer thread that pull-out log records from a thread-safe queue, filled on standard logging-write operations.
 
 