### PR TITLE
Add support for NOTICE level if defined in logging

### DIFF
--- a/graypy/handler.py
+++ b/graypy/handler.py
@@ -183,6 +183,8 @@ SYSLOG_LEVELS = {
     logging.INFO: 6,
     logging.DEBUG: 7,
 }
+if hasattr(logging, 'NOTICE'):
+  SYSLOG_LEVELS[logging.NOTICE] = 5
 
 
 def get_full_message(record):


### PR DESCRIPTION
I am wondering what your thoughts are on this.

For some reason or the other python went deliberately against using syslog standard levels. Graylog obviously does use them. There are some pypi packages available to retrofit the notice level to python, for example http://verboselogs.readthedocs.io/en/latest/readme.html
I think the default fallback (https://github.com/severb/graypy/blob/master/graypy/handler.py#L151) is not particularly helpful, since the value of python loglevels are defined in a completely different manner to syslog levels, so if I set NOTICE to be 25 graypy would pass 25 to graylog.

Another option to achieve the same thing would be to map the graylog loglevel using python loglevel ranges, something alongside
```python
def SYSLOG_LEVEL(python_level):
  if python_level >= 60: return 1 # ALERT
  if python_level >= 50: return 2 # CRITICAL
  if python_level >= 40: return 3 # ERROR
  if python_level >= 30: return 4 # WARNING
  if python_level >= 25: return 5 # NOTICE
  if python_level >= 20: return 6 # INFO
  return 7 # DEBUG
```
which would work for all custom log levels.

Or I could of course just modify graypy from within my code, and leave the graypy source alone.