### PR TITLE
Skip messages with more than 128 chunks

### DIFF
--- a/graypy/handler.py
+++ b/graypy/handler.py
@@ -116,7 +116,14 @@ class ChunkedGELF(object):
     def __init__(self, message, size):
         self.message = message
         self.size = size
-        self.pieces = struct.pack('B', int(math.ceil(len(message) * 1.0/size)))
+
+        # a message MUST NOT consist of more than 128 chunks
+        chunks_count = int(math.ceil(len(message) * 1.0/size))
+        if chunks_count > 128:
+            chunks_count = 0
+            self.message = ''
+
+        self.pieces = struct.pack('B', chunks_count)
         self.id = struct.pack('Q', random.randint(0, 0xFFFFFFFFFFFFFFFF))
 
     def message_chunks(self):


### PR DESCRIPTION
According to GELF specification a message must not consists of more than 128 chunks (http://docs.graylog.org/en/latest/pages/gelf.html#chunking). 

If you try to send a big message in more than 255 chunks `GELFHandler.send` will raise `struct.error` exception since sequence count is 1 byte, see https://gist.github.com/akhoronko/98665bf5229daf92f621d677239fbb83

