### PR TITLE
Gelf tcp tls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ matrix:
     include:
         - python: 2.7
           env: TOXENV=py27
-        - python: 3.3
-          env: TOXENV=py33
         - python: 3.4
           env: TOXENV=py34
         - python: 3.5

--- a/README.rst
+++ b/README.rst
@@ -83,24 +83,13 @@ GELFTcpHandler:
   * **facility** - replace facility with specified value. if specified, record.name will be passed as *logger* parameter.
   * **level_names** - allows the use of string error level names instead in addition to their numerical representation.
   * **tls** - use transport layer security on connection to graylog if true (not the default)
-  * **tls_server_name** - if using TLS, specify the name of the host
-        to which the connection is being made. if not specified, hostname
-        checking will not be performed.
-  * **param tls_cafile** - if using TLS, optionally specify a file with a set
-        of certificate authority certificates to use in certificate
-        validation.
-  * **param tls_capath** - if using TLS, optionally specify a path to files
-        with a set of certificate authority certificates to use in
-        certificate validation.
-  * **param tls_cadata** - if using TLS, optionally specify an object with
-        a set of certificate authority certificates to use in certificate
-        validation.
-  * **param tls_client_cert** - if using TLS, optionally specify a certificate
-        to authenticate the client to the graylog server.
-  * **param tls_client_key** - if using TLS, optionally specify a key file
-        corresponding to the client certificate.
-  * **param tls_client_password** - if using TLS, optionally specify a
-        password corresponding to the client key file.
+  * **tls_server_name** - if using TLS, specify the name of the host to which the connection is being made. if not specified, hostname checking will not be performed.
+  * **param tls_cafile** - if using TLS, optionally specify a file with a set of certificate authority certificates to use in certificate validation.
+  * **param tls_capath** - if using TLS, optionally specify a path to files with a set of certificate authority certificates to use in certificate validation.
+  * **param tls_cadata** - if using TLS, optionally specify an object with a set of certificate authority certificates to use in certificate validation.
+  * **param tls_client_cert** - if using TLS, optionally specify a certificate to authenticate the client to the graylog server.
+  * **param tls_client_key** - if using TLS, optionally specify a key file corresponding to the client certificate.
+  * **param tls_client_password** - if using TLS, optionally specify a password corresponding to the client key file.
 
 GELFRabbitHandler:
 

--- a/README.rst
+++ b/README.rst
@@ -95,6 +95,12 @@ GELFTcpHandler:
   * **param tls_cadata** - if using TLS, optionally specify an object with
         a set of certificate authority certificates to use in certificate
         validation.
+  * **param tls_client_cert** - if using TLS, optionally specify a certificate
+        to authenticate the client to the graylog server.
+  * **param tls_client_key** - if using TLS, optionally specify a key file
+        corresponding to the client certificate.
+  * **param tls_client_password** - if using TLS, optionally specify a
+        password corresponding to the client key file.
 
 GELFRabbitHandler:
 

--- a/README.rst
+++ b/README.rst
@@ -83,6 +83,18 @@ GELFTcpHandler:
   * **facility** - replace facility with specified value. if specified, record.name will be passed as *logger* parameter.
   * **level_names** - allows the use of string error level names instead in addition to their numerical representation.
   * **tls** - use transport layer security on connection to graylog if true (not the default)
+  * **tls_server_name** - if using TLS, specify the name of the host
+        to which the connection is being made. if not specified, hostname
+        checking will not be performed.
+  * **param tls_cafile** - if using TLS, optionally specify a file with a set
+        of certificate authority certificates to use in certificate
+        validation.
+  * **param tls_capath** - if using TLS, optionally specify a path to files
+        with a set of certificate authority certificates to use in
+        certificate validation.
+  * **param tls_cadata** - if using TLS, optionally specify an object with
+        a set of certificate authority certificates to use in certificate
+        validation.
 
 GELFRabbitHandler:
 

--- a/README.rst
+++ b/README.rst
@@ -71,6 +71,19 @@ GELFHandler:
   * **facility** - replace facility with specified value. if specified, record.name will be passed as *logger* parameter.
   * **level_names** - allows the use of string error level names instead in addition to their numerical representation.
 
+GELFTcpHandler:
+
+  * **host** - the host of the graylog server.
+  * **port** - the port of the graylog server (default 12201).
+  * **chunk_size** - message chunk size. messages larger than this size will be sent to graylog in multiple chunks (default `1420`).
+  * **debugging_fields** - send debug fields if true (the default).
+  * **extra_fields** - send extra fields on the log record to graylog if true (the default).
+  * **fqdn** - use fully qualified domain name of localhost as source host (socket.getfqdn()).
+  * **localname** - use specified hostname as source host.
+  * **facility** - replace facility with specified value. if specified, record.name will be passed as *logger* parameter.
+  * **level_names** - allows the use of string error level names instead in addition to their numerical representation.
+  * **tls** - use transport layer security on connection to graylog if true (not the default)
+
 GELFRabbitHandler:
 
   * **url** - RabbitMQ URL (ex: amqp://guest:guest@localhost:5672/%2F).

--- a/graypy/handler.py
+++ b/graypy/handler.py
@@ -102,19 +102,35 @@ class GELFTcpHandler(BaseGELFHandler, SocketHandler):
     :param tls_server_name: If using TLS, specify the name of the host
         to which the connection is being made. If not specified, hostname
         checking will not be performed.
+    :param tls_cafile: If using TLS, optionally specify a file with a set
+        of certificate authority certificates to use in certificate
+        validation.
+    :param tls_capath: If using TLS, optionally specify a path to files
+        with a set of certificate authority certificates to use in
+        certificate validation.
+    :param tls_cadata: If using TLS, optionally specify an object with
+        a set of certificate authority certificates to use in certificate
+        validation.
     """
     def __init__(self, host, port=12201, chunk_size=WAN_CHUNK,
                  debugging_fields=True, extra_fields=True, fqdn=False,
                  localname=None, facility=None, level_names=False,
-                 tls=False, tls_server_name=None):
+                 tls=False, tls_server_name=None, tls_cafile=None,
+                 tls_capath=None, tls_cadata=None):
         BaseGELFHandler.__init__(self, host, port, chunk_size,
                                  debugging_fields, extra_fields, fqdn,
                                  localname, facility, level_names, False)
         SocketHandler.__init__(self, host, int(port))
         self.tls = tls
         if self.tls:
+            self.tls_cafile = tls_cafile
+            self.tls_capath = tls_capath
+            self.tls_cadata = tls_cadata
+
             self.ssl_context = ssl.create_default_context(
-                purpose=ssl.Purpose.SERVER_AUTH)
+                purpose=ssl.Purpose.SERVER_AUTH, cafile=self.tls_cafile,
+                capath=self.tls_capath, cadata=self.tls_cadata
+            )
             self.tls_server_name = tls_server_name
             self.ssl_context.check_hostname = (self.tls_server_name
                                                is not None)

--- a/graypy/handler.py
+++ b/graypy/handler.py
@@ -97,7 +97,6 @@ class GELFTcpHandler(BaseGELFHandler, SocketHandler):
         record.name will be passed as `logger` parameter.
     :param level_names: Allows the use of string error level names instead
         of numerical values. Defaults to False
-    :param compress: Use message compression. Defaults to True
     :param tls: Use transport layer security on connection to graylog
         if true (not the default)
     """
@@ -105,7 +104,6 @@ class GELFTcpHandler(BaseGELFHandler, SocketHandler):
                  debugging_fields=True, extra_fields=True, fqdn=False,
                  localname=None, facility=None, level_names=False,
                  tls=False):
-        # compress = False always
         BaseGELFHandler.__init__(self, host, port, chunk_size,
                                  debugging_fields, extra_fields, fqdn,
                                  localname, facility, level_names, False)

--- a/graypy/handler.py
+++ b/graypy/handler.py
@@ -111,12 +111,19 @@ class GELFTcpHandler(BaseGELFHandler, SocketHandler):
     :param tls_cadata: If using TLS, optionally specify an object with
         a set of certificate authority certificates to use in certificate
         validation.
+    :param tls_client_cert: If using TLS, optionally specify a certificate
+        to authenticate the client to the graylog server.
+    :param tls_client_key: If using TLS, optionally specify a key file
+        corresponding to the client certificate.
+    :param tls_client_password: If using TLS, optionally specify a
+        password corresponding to the client key file.
     """
     def __init__(self, host, port=12201, chunk_size=WAN_CHUNK,
                  debugging_fields=True, extra_fields=True, fqdn=False,
                  localname=None, facility=None, level_names=False,
                  tls=False, tls_server_name=None, tls_cafile=None,
-                 tls_capath=None, tls_cadata=None):
+                 tls_capath=None, tls_cadata=None, tls_client_cert=None,
+                 tls_client_key=None, tls_client_password=None):
         BaseGELFHandler.__init__(self, host, port, chunk_size,
                                  debugging_fields, extra_fields, fqdn,
                                  localname, facility, level_names, False)
@@ -126,6 +133,9 @@ class GELFTcpHandler(BaseGELFHandler, SocketHandler):
             self.tls_cafile = tls_cafile
             self.tls_capath = tls_capath
             self.tls_cadata = tls_cadata
+            self.tls_client_cert = tls_client_cert
+            self.tls_client_key = tls_client_key
+            self.tls_client_password = tls_client_password
 
             self.ssl_context = ssl.create_default_context(
                 purpose=ssl.Purpose.SERVER_AUTH, cafile=self.tls_cafile,
@@ -134,6 +144,10 @@ class GELFTcpHandler(BaseGELFHandler, SocketHandler):
             self.tls_server_name = tls_server_name
             self.ssl_context.check_hostname = (self.tls_server_name
                                                is not None)
+            if self.tls_client_cert is not None:
+                self.ssl_context.load_cert_chain(self.tls_client_cert,
+                                                 self.tls_client_key,
+                                                 self.tls_client_password)
 
     def makeSocket(self, timeout=None):
         """Override SocketHandler.makeSocket, to allow creating

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,py35,pypy
+envlist = py27,py34,py35,pypy
 
 [testenv]
 commands =


### PR DESCRIPTION
I made some adjustments to GELFTcpHandler to facilitate using ssl to wrap sockets. This allows Graypy to be used to connect to TLS enabled TCP inputs on a Graylog server.

Addresses Issue #86 