### PR TITLE
add 'level_names' for 'GELFRabbitHandler'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,6 +101,7 @@ GELFRabbitHandler:
   * **exchange_type** - RabbitMQ exchange type (default `fanout`).
   * **localname** - use specified hostname as source host.
   * **facility** - replace facility with specified value. if specified, record.name will be passed as `logger` parameter.
+  * **level_names** - allows the use of string error level names instead in addition to their numerical representation.
 
 Using with Django
 =================

--- a/graypy/rabbitmq.py
+++ b/graypy/rabbitmq.py
@@ -32,11 +32,13 @@ class GELFRabbitHandler(SocketHandler):
     :param localname: Use specified hostname as source host.
     :param facility: Replace facility with specified value. If specified,
         record.name will be passed as `logger` parameter.
+    :param level_names: Allows the use of string error level names instead
+        of numerical values. Defaults to False
     """
 
     def __init__(self, url, exchange='logging.gelf', debugging_fields=True,
                  extra_fields=True, fqdn=False, exchange_type='fanout', localname=None,
-                 facility=None, virtual_host='/', routing_key=''):
+                 facility=None, level_names=False, virtual_host='/', routing_key=''):
         self.url = url
         parsed = urlparse(url)
         if parsed.scheme != 'amqp':
@@ -58,6 +60,7 @@ class GELFRabbitHandler(SocketHandler):
         self.exchange_type = exchange_type
         self.localname = localname
         self.facility = facility
+        self.level_names = level_names
         self.virtual_host = virtual_host
         self.routing_key = routing_key
         SocketHandler.__init__(self, host, port)
@@ -69,8 +72,8 @@ class GELFRabbitHandler(SocketHandler):
 
     def makePickle(self, record):
         message_dict = make_message_dict(
-            record, self.debugging_fields, self.extra_fields, self.fqdn, self.localname,
-            self.facility)
+            record, self.debugging_fields, self.extra_fields, self.fqdn,
+            self.localname, self.level_names, self.facility)
         return json.dumps(message_dict)
 
 

--- a/perftest.py
+++ b/perftest.py
@@ -60,6 +60,11 @@ def main(argv=sys.argv):
             'formatter': 'message',
         }
         config['root']['handlers'].append('graylog_rabbit')
+        try:
+            from amqplib import client_0_8 as amqp
+        except ImportError:
+            msg = "Unable to test GELFRabbitHandler due to missing external dependency: amqplib"
+            raise RuntimeError(msg)
 
     if args.console_logger:
         config['handlers']['console'] = {

--- a/tox.ini
+++ b/tox.ini
@@ -8,3 +8,4 @@ commands =
 deps =
     pytest
     mock
+    amqplib


### PR DESCRIPTION
Another attempt to fix the missing 'level_names' argument. Without that field in the message payload, there is no way to display ro filter by 'level_name' field in Graylog.

The test script is also updated.