### PR TITLE
setup.py and project improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,111 @@
+### Python template
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
 dist/
-graypy.egg-info/
-*.pyc
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+# Pycharm
+.idea/
+
+# tox
 .tox
-.idea

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,407 @@
+[MASTER]
+
+# Specify a configuration file.
+#rcfile=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+init-hook='sys.path.append(os.path.abspath(os.path.curdir))'
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=tests
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Use multiple processes to speed up Pylint.
+jobs=4
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=
+
+# Allow optimization of some AST trees. This will activate a peephole AST
+# optimizer, which will apply various small optimizations. For instance, it can
+# be used to obtain the result of joining multiple strings with the addition
+# operator. Joining a lot of strings can lead to a maximum recursion error in
+# Pylint and this flag can prevent that. It has one side effect, the resulting
+# AST will be different than the one from reality. This option is deprecated
+# and it will be removed in Pylint 2.0.
+optimize-ast=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+#enable=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=locally-disabled,too-few-public-methods,no-self-use,too-many-ancestors,bad-continuation
+
+
+[REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized, msvs
+# (visual studio) and html. You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Put messages in a separate file for each module / package specified on the
+# command line instead of printing them on stdout. Reports (if any) will be
+# written in a file name "pylint_global.[txt|html]". This option is deprecated
+# and it will be removed in Pylint 2.0.
+files-output=no
+
+# Tells whether to display a full report or only the messages
+reports=yes
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[SIMILARITIES]
+
+# Minimum lines number of a similarity.
+min-similarity-lines=8
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,dict-separator
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=4
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+
+[SPELLING]
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[VARIABLES]
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=(_+[a-zA-Z0-9]*?$)|dummy
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,_cb
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,future.builtins
+
+
+[TYPECHECK]
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=flask_sqlalchemy,app.extensions.flask_sqlalchemy
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=fget,query,begin,add,merge,delete,commit,rollback
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,XXX,TODO
+
+
+[BASIC]
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,j,k,ex,Run,_,log,api
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,bar,baz,toto,tutu,tata
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+property-classes=abc.abstractproperty
+
+# Regular expression matching correct class names
+class-rgx=[A-Z_][a-zA-Z0-9]+$
+
+# Naming hint for class names
+class-name-hint=[A-Z_][a-zA-Z0-9]+$
+
+# Regular expression matching correct constant names
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Naming hint for constant names
+const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Regular expression matching correct argument names
+argument-rgx=[a-z_][a-z0-9_]{2,40}$
+
+# Naming hint for argument names
+argument-name-hint=[a-z_][a-z0-9_]{2,40}$
+
+# Regular expression matching correct inline iteration names
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+
+# Naming hint for inline iteration names
+inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
+
+# Regular expression matching correct method names
+method-rgx=[a-z_][a-z0-9_]{2,40}$
+
+# Naming hint for method names
+method-name-hint=[a-z_][a-z0-9_]{2,40}$
+
+# Regular expression matching correct function names
+function-rgx=[a-z_][a-z0-9_]{2,40}$
+
+# Naming hint for function names
+function-name-hint=[a-z_][a-z0-9_]{2,40}$
+
+# Regular expression matching correct class attribute names
+class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,40}|(__.*__))$
+
+# Naming hint for class attribute names
+class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,40}|(__.*__))$
+
+# Regular expression matching correct attribute names
+attr-rgx=[a-z_][a-z0-9_]{2,40}$
+
+# Naming hint for attribute names
+attr-name-hint=[a-z_][a-z0-9_]{2,40}$
+
+# Regular expression matching correct variable names
+variable-rgx=[a-z_][a-z0-9_]{2,40}$
+
+# Naming hint for variable names
+variable-name-hint=[a-z_][a-z0-9_]{2,40}$
+
+# Regular expression matching correct module names
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Naming hint for module names
+module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=5
+
+
+[ELIF]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=5
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*
+
+# Maximum number of locals for function / method body
+max-locals=15
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of branch for function / method body
+max-branches=12
+
+# Maximum number of statements in function / method body
+max-statements=50
+
+# Maximum number of parents for a class (see R0901).
+max-parents=10
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of boolean expressions in a if statement
+max-bool-expr=5
+
+
+[IMPORTS]
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=optparse
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=flask_restplus_patched
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,__new__,setUp
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source,_make
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ matrix:
           env: TOXENV=py35
         - python: 3.6
           env: TOXENV=py36
-        - python: 3.7
-          env: TOXENV=py37
         - python: pypy
           env: TOXENV=pypy
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ matrix:
           env: TOXENV=py35
         - python: 3.6
           env: TOXENV=py36
+        - python: 3.7
+          env: TOXENV=py37
         - python: pypy
           env: TOXENV=pypy
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ matrix:
           env: TOXENV=py34
         - python: 3.5
           env: TOXENV=py35
+        - python: 3.6
+          env: TOXENV=py36
         - python: pypy
           env: TOXENV=pypy
 

--- a/graypy/__init__.py
+++ b/graypy/__init__.py
@@ -8,6 +8,7 @@ GELF (Graylog Extended Log Format).
 """
 
 from graypy.handler import GELFHandler, GELFTcpHandler, WAN_CHUNK, LAN_CHUNK
+
 try:
     from graypy.rabbitmq import GELFRabbitHandler, ExcludeFilter
 except ImportError:

--- a/graypy/__init__.py
+++ b/graypy/__init__.py
@@ -1,5 +1,17 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""graypy
+
+Python logging handler that sends messages in
+GELF (Graylog Extended Log Format).
+"""
+
 from graypy.handler import GELFHandler, GELFTcpHandler, WAN_CHUNK, LAN_CHUNK
 try:
     from graypy.rabbitmq import GELFRabbitHandler, ExcludeFilter
 except ImportError:
-    pass # amqplib is probably not installed
+    pass  # amqplib is probably not installed
+
+
+__version__ = (0, 3, 1)

--- a/graypy/handler.py
+++ b/graypy/handler.py
@@ -1,3 +1,6 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
 import datetime
 import sys
 import logging
@@ -21,8 +24,9 @@ else:
 
 class BaseGELFHandler(object):
     def __init__(self, host, port=12201, chunk_size=WAN_CHUNK,
-            debugging_fields=True, extra_fields=True, fqdn=False,
-            localname=None, facility=None, level_names=False, compress=True):
+                 debugging_fields=True, extra_fields=True, fqdn=False,
+                 localname=None, facility=None, level_names=False,
+                 compress=True):
         self.debugging_fields = debugging_fields
         self.extra_fields = extra_fields
         self.chunk_size = chunk_size
@@ -39,7 +43,6 @@ class BaseGELFHandler(object):
         packed = message_to_pickle(message_dict)
         frame = zlib.compress(packed) if self.compress else packed
         return frame
-
 
 
 class GELFHandler(BaseGELFHandler, DatagramHandler):
@@ -201,7 +204,8 @@ def make_message_dict(record, debugging_fields, extra_fields, fqdn, localname,
         host = localname
     else:
         host = socket.gethostname()
-    fields = {'version': "1.0",
+    fields = {
+        'version': "1.0",
         'host': host,
         'short_message': record.getMessage(),
         'full_message': get_full_message(record),
@@ -233,6 +237,7 @@ def make_message_dict(record, debugging_fields, extra_fields, fqdn, localname,
     if extra_fields:
         fields = add_extra_fields(fields, record)
     return fields
+
 
 SYSLOG_LEVELS = {
     logging.CRITICAL: 2,

--- a/graypy/handler.py
+++ b/graypy/handler.py
@@ -20,7 +20,8 @@ WAN_CHUNK, LAN_CHUNK = 1420, 8154
 if PY3:
     data, text = bytes, str
 else:
-    data, text = str, unicode
+    data, text = str, unicode  # pylint: disable=undefined-variable
+
 
 class BaseGELFHandler(object):
     def __init__(self, host, port=12201, chunk_size=WAN_CHUNK,

--- a/graypy/handler.py
+++ b/graypy/handler.py
@@ -298,7 +298,7 @@ def message_to_pickle(obj):
 
 
 def sanitize(obj):
-    """Convert all strings records of the object to unicode """
+    """Convert all strings records of the object to unicode"""
     if isinstance(obj, dict):
         return dict((sanitize(k), sanitize(v)) for k, v in obj.items())
     if isinstance(obj, (list, tuple)):

--- a/graypy/handler.py
+++ b/graypy/handler.py
@@ -4,16 +4,16 @@
 """Logging Handlers that sends messages in GELF (Graylog Extended Log Format)"""
 
 import datetime
-import sys
-import logging
 import json
-import zlib
-import traceback
-import struct
+import logging
+import math
 import random
 import socket
 import ssl
-import math
+import struct
+import sys
+import traceback
+import zlib
 from logging.handlers import DatagramHandler, SocketHandler
 
 PY3 = sys.version_info[0] == 3

--- a/graypy/rabbitmq.py
+++ b/graypy/rabbitmq.py
@@ -1,6 +1,9 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+"""Logging Handler intergrating RabbitMQ and Graylog Extended Log Format
+handler"""
+
 import json
 from amqplib import client_0_8 as amqp
 from graypy.handler import make_message_dict

--- a/graypy/rabbitmq.py
+++ b/graypy/rabbitmq.py
@@ -5,10 +5,12 @@
 handler"""
 
 import json
-from amqplib import client_0_8 as amqp
-from graypy.handler import make_message_dict
 from logging import Filter
 from logging.handlers import SocketHandler
+
+from amqplib import client_0_8 as amqp  # pylint: disable=import-error
+
+from graypy.handler import make_message_dict
 
 try:
     from urllib.parse import urlparse, unquote

--- a/graypy/rabbitmq.py
+++ b/graypy/rabbitmq.py
@@ -1,3 +1,6 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
 import json
 from amqplib import client_0_8 as amqp
 from graypy.handler import make_message_dict

--- a/graypy/rabbitmq.py
+++ b/graypy/rabbitmq.py
@@ -43,8 +43,9 @@ class GELFRabbitHandler(SocketHandler):
     """
 
     def __init__(self, url, exchange='logging.gelf', debugging_fields=True,
-                 extra_fields=True, fqdn=False, exchange_type='fanout', localname=None,
-                 facility=None, virtual_host='/', routing_key=''):
+                 extra_fields=True, fqdn=False, exchange_type='fanout',
+                 localname=None, facility=None, virtual_host='/',
+                 routing_key=''):
         self.url = url
         parsed = urlparse(url)
         if parsed.scheme != 'amqp':
@@ -77,8 +78,13 @@ class GELFRabbitHandler(SocketHandler):
 
     def makePickle(self, record):
         message_dict = make_message_dict(
-            record, self.debugging_fields, self.extra_fields, self.fqdn, self.localname,
-            self.facility)
+            record,
+            self.debugging_fields,
+            self.extra_fields,
+            self.fqdn,
+            self.localname,
+            self.facility
+        )
         return json.dumps(message_dict)
 
 
@@ -101,7 +107,11 @@ class RabbitSocket(object):
 
     def sendall(self, data):
         msg = amqp.Message(data, delivery_mode=2)
-        self.channel.basic_publish(msg, exchange=self.exchange, routing_key=self.routing_key)
+        self.channel.basic_publish(
+            msg,
+            exchange=self.exchange,
+            routing_key=self.routing_key
+        )
 
     def close(self):
         try:

--- a/perftest.py
+++ b/perftest.py
@@ -1,9 +1,12 @@
-#! /usr/bin/env python
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
 import argparse
 import logging
 import logging.config
 import sys
 import time
+
 
 def main(argv=sys.argv):
     parser = argparse.ArgumentParser(prog="perftest.py")
@@ -93,14 +96,15 @@ def main(argv=sys.argv):
                 elapsed = time.time() - (tx - 1)
                 tx += 1
                 print('%s messages in %.3f seconds (%.3f msg/s)'
-                    % (cx, elapsed, cx / elapsed))
+                      % (cx, elapsed, cx / elapsed))
                 cx = 0
                 if tx > t_end:
                     break
 
     elapsed = time.time() - t_start
     print('%s messages in %.3f seconds (%.3f msg/s)'
-        % (total, elapsed, total / elapsed))
+          % (total, elapsed, total / elapsed))
+
 
 if __name__ == '__main__':
     main()

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
         "pytest-timeout",
         "pylint>=1.9.1,<2.0.0",
         "mock>=2.0.0,<3.0.0",
+        "tox>=3.4.0,<4.0.0"
     ],
     extras_require={'amqp': ['amqplib==1.0.2']},
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ VERSION = find_version("graypy", "__init__.py")
 class Pylint(test):
     def run_tests(self):
         from pylint.lint import Run
-        Run(["graypy", "--persistent", "y"])
+        Run(["graypy", "--persistent", "y", "--rcfile", ".pylintrc"])
 
 
 class PyTest(test):

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ VERSION = find_version("graypy", "__init__.py")
 class Pylint(test):
     def run_tests(self):
         from pylint.lint import Run
-        Run(["trivector", "--persistent", "y"])
+        Run(["graypy", "--persistent", "y"])
 
 
 class PyTest(test):

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,53 @@
-#!/usr/bin/env python
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""setup.py for graypy"""
+
+import codecs
+import re
+import sys
+import os
 
 from setuptools import setup, find_packages
+from setuptools.command.test import test
+
+
+def find_version(*file_paths):
+    with codecs.open(os.path.join(os.path.abspath(os.path.dirname(__file__)), *file_paths), 'r') as fp:
+        version_file = fp.read()
+    m = re.search(r"^__version__ = \((\d+), ?(\d+), ?(\d+)\)", version_file, re.M)
+    if m:
+        return "{}.{}.{}".format(*m.groups())
+    raise RuntimeError("Unable to find a valid version")
+
+
+VERSION = find_version("graypy", "__init__.py")
+
+
+class Pylint(test):
+    def run_tests(self):
+        from pylint.lint import Run
+        Run(["trivector", "--persistent", "y"])
+
+
+class PyTest(test):
+    user_options = [('pytest-args=', 'a', "Arguments to pass to pytest")]
+
+    def initialize_options(self):
+        test.initialize_options(self)
+        self.pytest_args = "-v --cov={}".format("graypy")
+
+    def run_tests(self):
+        import shlex
+        # import here, cause outside the eggs aren't loaded
+        import pytest
+        errno = pytest.main(shlex.split(self.pytest_args))
+        sys.exit(errno)
+
 
 setup(
-
     name='graypy',
-    version='0.3.1',
+    version=VERSION,
     description="Python logging handler that sends messages in GELF (Graylog Extended Log Format).",
     long_description=open('README.rst').read(),
     keywords='logging gelf graylog2 graylog udp amqp',
@@ -16,8 +58,18 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
+    tests_require=[
+        "pytest",
+        "pytest-cov",
+        "pytest-timeout",
+        "pylint>=1.9.1,<2.0.0",
+        "mock>=2.0.0,<3.0.0",
+    ],
     extras_require={'amqp': ['amqplib==1.0.2']},
-    classifiers=['License :: OSI Approved :: BSD License',
-                 'Programming Language :: Python :: 2',
-                 'Programming Language :: Python :: 3'],
+    classifiers=[
+        'License :: OSI Approved :: BSD License',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3'
+    ],
+    cmdclass={"test": PyTest, "lint": Pylint},
 )

--- a/tests/test_gelf_datagram.py
+++ b/tests/test_gelf_datagram.py
@@ -4,12 +4,13 @@
 import datetime
 import json
 import logging
-import pytest
-import zlib
-import mock
 import sys
-from graypy.handler import GELFHandler, message_to_pickle
+import zlib
 
+import mock
+import pytest
+
+from graypy.handler import GELFHandler, message_to_pickle
 
 UNICODE_REPLACEMENT = u'\ufffd'
 

--- a/tests/test_gelf_datagram.py
+++ b/tests/test_gelf_datagram.py
@@ -1,4 +1,6 @@
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
+
 import datetime
 import json
 import logging

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 ; TODO: add py36? py37?
-envlist = py27,py34,py35,pypy
+envlist = py27,py34,py35,py36,pypy
 
 [testenv]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 ; TODO: add py36? py37?
-envlist = py27,py34,py35,py36,py37,pypy
+envlist = py27,py34,py35,py36,pypy
 
 [testenv]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 ; TODO: add py36? py37?
-envlist = py27,py34,py35,py36,pypy
+envlist = py27,py34,py35,py36,py37,pypy
 
 [testenv]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+; TODO: add py36? py37?
 envlist = py27,py34,py35,pypy
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,7 @@ envlist = py27,py34,py35,pypy
 
 [testenv]
 commands =
-  py.test -vv --pdb
-
-deps =
-    pytest
-    mock
+  python setup.py test
+;  TODO: lint test only works well in a linux enviroment due to
+;  handling of pylints error codes
+;  python setup.py lint || exit $(($? & 35))


### PR DESCRIPTION
General improvements to the `setup.py` of `graypy`:
* `pytest` (hooks implemented and used in tox tests)
* `pylint` (hooks implemented but not used in tox tests)
* added `tests_requires` to make setup of a testing environment easier.
* moved version information within `graypy/__init__.py`.

Other changes:
* `tox` now executes `python setup.py test` to call `pytest`
* refactoring and documentation push across the project
* `.pylintrc` added for `pylint` tests
* `.gitignore` follows a generic python gitignore template

Behavior of `graypy` is unchanged, this simply tries to cleanup the source code and help in setting up a development/testing environment for `graypy`.

**TODO:** `pylint` testing is currently disabled for this project as it requires bash operators to check/modify the return code of the pylint test. It can still be invoked by `python setup.py lint` and validated manually.
