### PR TITLE
JSON Serialization Improvements for GELFRabbitHandler

### DIFF
--- a/graypy/handler.py
+++ b/graypy/handler.py
@@ -9,6 +9,7 @@ import random
 import socket
 import ssl
 import math
+import enum
 from logging.handlers import DatagramHandler, SocketHandler
 
 PY3 = sys.version_info[0] == 3
@@ -276,6 +277,10 @@ def smarter_repr(obj):
     """ convert JSON incompatible object to string"""
     if isinstance(obj, datetime.datetime):
         return obj.isoformat()
+    if isinstance(obj, enum.Enum):
+        return repr({obj.name: obj.value})
+    if hasattr(obj, "__dict__"):
+        return repr(obj.__dict__)
     return repr(obj)
 
 

--- a/graypy/rabbitmq.py
+++ b/graypy/rabbitmq.py
@@ -1,6 +1,6 @@
 import json
 from amqplib import client_0_8 as amqp
-from graypy.handler import make_message_dict
+from graypy.handler import make_message_dict, smarter_repr
 from logging import Filter
 from logging.handlers import SocketHandler
 
@@ -71,7 +71,7 @@ class GELFRabbitHandler(SocketHandler):
         message_dict = make_message_dict(
             record, self.debugging_fields, self.extra_fields, self.fqdn, self.localname,
             self.facility)
-        return json.dumps(message_dict)
+        return json.dumps(message_dict, default=smarter_repr)
 
 
 class RabbitSocket(object):


### PR DESCRIPTION
- Made smarter_repr smarter (handles enums and tries to use __dict__ for other objects.  Needed for my use-case of logging data from the `nameko-tracer` extension to the `nameko` microservice framework)

- Told `GELFRabbitHandler` to use smarter_repr when serialising its final object