### PR TITLE
Feature/handle chunk overflow

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,6 +92,24 @@ the ``GELFUDPHandler``:
 
     my_logger.debug('Hello Graylog.')
 
+
+UDP GELF Chunkers
+^^^^^^^^^^^^^^^^^
+
+`GELF UDP Chunking`_ is supported by the ``GELFUDPHandler`` and is defined by
+the ``gelf_chunker`` argument within its constructor. By default the
+``GELFWarningChunker`` is used, thus, GELF messages that chunk overflow
+(i.e. consisting of more than 128 chunks) will issue a
+``GELFChunkOverflowWarning`` and **will be dropped**.
+
+Other ``gelf_chunker`` options are also available:
+
+* ``BaseGELFChunker`` silently drops GELF messages that chunk overflow
+* ``GELFTruncatingChunker`` issues a ``GELFChunkOverflowWarning`` and
+  simplifies and truncates GELF messages that chunk overflow in a attempt
+  to send some content to Graylog. If this process fails to prevent
+  another chunk overflow a ``GELFTruncationFailureWarning`` is issued.
+
 RabbitMQ Logging
 ----------------
 
@@ -253,5 +271,6 @@ Contributors
 
 .. _GELF: https://docs.graylog.org/en/latest/pages/gelf.html
 .. _logging.Handler: https://docs.python.org/3/library/logging.html#logging.Handler
+.. _GELF UDP Chunking: https://docs.graylog.org/en/latest/pages/gelf.html#chunking
 .. _LoggerAdapter: https://docs.python.org/howto/logging-cookbook.html#using-loggeradapters-to-impart-contextual-information
 .. _Filter: https://docs.python.org/howto/logging-cookbook.html#using-filters-to-impart-contextual-information

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -146,6 +146,11 @@ intersphinx_mapping = {
 
 
 # -- auto api docs generation --
+
+# order auto doc members by position in source code
+autodoc_member_order = 'bysource'
+
+
 def run_apidoc(_):
     from sphinx.ext.apidoc import main
     import os

--- a/graypy/handler.py
+++ b/graypy/handler.py
@@ -307,7 +307,7 @@ class BaseGELFHandler(logging.Handler, ABC):
             separators=',:',
             default=cls._object_to_json
         )
-        return packed._encode('utf-8')
+        return packed.encode('utf-8')
 
     @classmethod
     def _sanitize_to_unicode(cls, obj):

--- a/graypy/handler.py
+++ b/graypy/handler.py
@@ -307,7 +307,7 @@ class BaseGELFHandler(logging.Handler, ABC):
             separators=',:',
             default=cls._object_to_json
         )
-        return packed.encode('utf-8')
+        return packed._encode('utf-8')
 
     @classmethod
     def _sanitize_to_unicode(cls, obj):
@@ -371,7 +371,7 @@ class BaseGELFChunker(object):
         return int(math.ceil(len(message) * 1.0 / self.chunk_size))
 
     @staticmethod
-    def encode(message_id, chunk_seq, total_chunks, chunk):
+    def _encode(message_id, chunk_seq, total_chunks, chunk):
         return b''.join([
             b'\x1e\x0f',
             struct.pack('Q', message_id),
@@ -385,7 +385,7 @@ class BaseGELFChunker(object):
         message_id = random.randint(0, 0xFFFFFFFFFFFFFFFF)
         for sequence, chunk in enumerate((message[i:i + self.chunk_size]
                           for i in range(0, len(message), self.chunk_size))):
-            yield self.encode(message_id, sequence, total_chunks, chunk)
+            yield self._encode(message_id, sequence, total_chunks, chunk)
 
     def chunk_message(self, message):
         """Chunk a GELF message

--- a/graypy/handler.py
+++ b/graypy/handler.py
@@ -432,7 +432,8 @@ class GELFTruncatingChunker(BaseGELFChunker):
         self.gelf_packer = gelf_packer
         self.compress = compress
 
-    def _init_truncated_glef_dict(self, glef_dict):
+    @staticmethod
+    def _init_truncated_glef_dict(glef_dict):
         return {
             'version': glef_dict['version'],
             'host': glef_dict['host'],

--- a/graypy/handler.py
+++ b/graypy/handler.py
@@ -474,8 +474,6 @@ class GELFUDPHandler(BaseGELFHandler, DatagramHandler):
         :param gelf_chunker:
         :type gelf_chunker: GELFChunker
         """
-        self.chunk_size = chunk_size
-
         BaseGELFHandler.__init__(self, **kwargs)
         DatagramHandler.__init__(self, host, port)
         self.gelf_chunker = gelf_chunker

--- a/graypy/handler.py
+++ b/graypy/handler.py
@@ -414,6 +414,10 @@ class GELFWarningChunker(BaseGELFChunker):
             yield chunk
 
 
+class GELFTruncationFailureWarning(Warning):
+    """Warning that the truncation of a chunked GELF UDP message failed"""
+
+
 class GELFTruncatingChunker(BaseGELFChunker):
     """GELF UDP message chunker that truncates overflowing messages"""
 
@@ -481,7 +485,7 @@ class GELFTruncatingChunker(BaseGELFChunker):
             try:
                 message = self.gen_chunk_overflow_gelf_log(message)
             except (zlib.error, ValueError):
-                warnings.warn("Failed truncating GELF chunk overflowing message: {}".format(traceback.format_exc()), GELFChunkOverflowWarning)
+                warnings.warn("Failed truncating GELF chunk overflowing message: {}".format(traceback.format_exc()), GELFTruncationFailureWarning)
                 return
         for chunk in self._gen_gelf_chunks(message):
             yield chunk

--- a/graypy/handler.py
+++ b/graypy/handler.py
@@ -428,6 +428,21 @@ class GELFTruncatingChunker(BaseGELFChunker):
         self.gelf_packer = gelf_packer
 
     def get_initial_truncate_offset(self, gelf_message, compressed):
+        """Compute the amount of chunks the simplified GELF message
+        without a ``short_message`` field will use
+
+        :param gelf_message: GELF dictionary representation of the original
+            overflowing GELF message.
+        :type gelf_message: dict
+
+        :param compressed: Boolean noting whether the given gelf_message
+            was originally compressed.
+        :type compressed: bool
+
+        :return: Amount of chunks the simplified GELF message without the
+            original ``short_message`` field will use.
+        :rtype: int
+        """
         gelf_dict_pre = {
             'version': gelf_message['version'],
             'host': gelf_message['host'],

--- a/graypy/handler.py
+++ b/graypy/handler.py
@@ -483,7 +483,7 @@ class GELFUDPHandler(BaseGELFHandler, DatagramHandler):
         self.gelf_chunker = gelf_chunker
 
     def send(self, s):
-        if len(s) < self.chunk_size:
+        if len(s) < self.gelf_chunker.chunk_size:
             super(GELFUDPHandler, self).send(s)
         else:
             for chunk in self.gelf_chunker.iter_gelf_chunks(s):

--- a/graypy/handler.py
+++ b/graypy/handler.py
@@ -432,14 +432,14 @@ class GELFTruncatingChunker(BaseGELFChunker):
         self.gelf_packer = gelf_packer
         self.compress = compress
 
-    def _init_truncated_glef_dict(self, gelf_message):
+    def _init_truncated_glef_dict(self, glef_dict):
         return {
-            'version': gelf_message['version'],
-            'host': gelf_message['host'],
+            'version': glef_dict['version'],
+            'host': glef_dict['host'],
             'short_message': "",
-            'timestamp': gelf_message['timestamp'],
+            'timestamp': glef_dict['timestamp'],
             'level': SYSLOG_LEVELS.get(logging.ERROR, logging.ERROR),
-            'facility': gelf_message['facility'],
+            'facility': glef_dict['facility'],
             '_chunk_overflow': True,
         }
 

--- a/graypy/handler.py
+++ b/graypy/handler.py
@@ -346,10 +346,6 @@ class BaseGELFHandler(logging.Handler, ABC):
         return repr(obj)
 
 
-class GELFChunkOverflowWarning(Warning):
-    """Warning that a chunked GELF UDP message requires more than 128 chunks"""
-
-
 class BaseGELFChunker(object):
     """Base UDP GELF message chunker
 
@@ -419,6 +415,10 @@ class BaseGELFChunker(object):
             return
         for chunk in self._gen_gelf_chunks(message):
             yield chunk
+
+
+class GELFChunkOverflowWarning(Warning):
+    """Warning that a chunked GELF UDP message requires more than 128 chunks"""
 
 
 class GELFWarningChunker(BaseGELFChunker):

--- a/graypy/handler.py
+++ b/graypy/handler.py
@@ -124,7 +124,7 @@ class BaseGELFHandler(logging.Handler, ABC):
         :param record: :class:`logging.LogRecord` to create a GELF log from.
         :type record: logging.LogRecord
 
-        :return: dictionary representing a GELF log.
+        :return: Dictionary representing a GELF log.
         :rtype: dict
         """
         # construct the base GELF format
@@ -155,7 +155,7 @@ class BaseGELFHandler(logging.Handler, ABC):
         the logging level via the string error level names instead of
         numerical values
 
-        :param gelf_dict: dictionary representing a GELF log.
+        :param gelf_dict: Dictionary representing a GELF log.
         :type gelf_dict: dict
 
         :param record: :class:`logging.LogRecord` to extract a logging
@@ -171,7 +171,7 @@ class BaseGELFHandler(logging.Handler, ABC):
         Also add a additional ``_logger`` field containing the
         ``LogRecord.name``.
 
-        :param gelf_dict: dictionary representing a GELF log.
+        :param gelf_dict: Dictionary representing a GELF log.
         :type gelf_dict: dict
 
         :param facility_value: Value to set as the ``gelf_dict``'s
@@ -190,7 +190,7 @@ class BaseGELFHandler(logging.Handler, ABC):
         """Add the ``full_message`` field to the ``gelf_dict`` if any
         traceback information exists within the logging record
 
-        :param gelf_dict: dictionary representing a GELF log.
+        :param gelf_dict: Dictionary representing a GELF log.
         :type gelf_dict: dict
 
         :param record: :class:`logging.LogRecord` to extract a full
@@ -234,7 +234,7 @@ class BaseGELFHandler(logging.Handler, ABC):
     def _add_debugging_fields(gelf_dict, record):
         """Add debugging fields to the given ``gelf_dict``
 
-        :param gelf_dict: dictionary representing a GELF log.
+        :param gelf_dict: Dictionary representing a GELF log.
         :type gelf_dict: dict
 
         :param record: :class:`logging.LogRecord` to extract debugging
@@ -269,7 +269,7 @@ class BaseGELFHandler(logging.Handler, ABC):
 
                 http://docs.python.org/library/logging.html#logrecord-attributes
 
-        :param gelf_dict: dictionary representing a GELF log.
+        :param gelf_dict: Dictionary representing a GELF log.
         :type gelf_dict: dict
 
         :param record: :class:`logging.LogRecord` to extract extra fields
@@ -295,10 +295,10 @@ class BaseGELFHandler(logging.Handler, ABC):
         Since we cannot be 100% sure of what is contained in the ``gelf_dict``
         we have to do some sanitation.
 
-        :param gelf_dict: dictionary representing a GELF log.
+        :param gelf_dict: Dictionary representing a GELF log.
         :type gelf_dict: dict
 
-        :return: bytes representing a uncompressed GELF log.
+        :return: Bytes representing a uncompressed GELF log.
         :rtype: bytes
         """
         gelf_dict = cls._sanitize_to_unicode(gelf_dict)
@@ -313,7 +313,7 @@ class BaseGELFHandler(logging.Handler, ABC):
     def _sanitize_to_unicode(cls, obj):
         """Convert all strings records of the object to unicode
 
-        :param obj: object to sanitize to unicode.
+        :param obj: Object to sanitize to unicode.
         :type obj: object
 
         :return: Unicode string representing the given object.
@@ -335,7 +335,7 @@ class BaseGELFHandler(logging.Handler, ABC):
         :class:`datetime.datetime` based objects will be converted into a
         ISO formatted timestamp string.
 
-        :param obj: object to convert into a string representation.
+        :param obj: Object to convert into a string representation.
         :type obj: object
 
         :return: String representing the given object.
@@ -388,6 +388,14 @@ class BaseGELFChunker(object):
             yield self.encode(message_id, sequence, total_chunks, chunk)
 
     def chunk_message(self, message):
+        """Chunk a GELF message
+
+        :param message: GELF message to chunk.
+        :type; bytes
+
+        :return: Iterator of the chunks of a GELF message.
+        :rtype: Iterator[bytes], None
+        """
         if self.get_message_chunk_number(message) > GELF_MAX_CHUNK_NUMBER:
             # silently drop messages that exceed the max gelf chunk size
             return
@@ -412,7 +420,7 @@ class GELFTruncatingChunker(BaseGELFChunker):
     def __init__(self, chunk_size=WAN_CHUNK, gelf_packer=BaseGELFHandler._pack_gelf_dict):
         """Initialize the GELFTruncatingChunker.
 
-        :param gelf_packer: A function handle for pracking a GELF dictionary
+        :param gelf_packer: Function handle for pracking a GELF dictionary
             into bytes. Should be of the form ``gelf_packer(gelf_dict)``.
         :type gelf_packer: Callable[dict]
         """

--- a/graypy/handler.py
+++ b/graypy/handler.py
@@ -537,14 +537,13 @@ class ChunkedGELF(object):
         :param size: The size of the chunks.
         :type size: int
         """
-        print(message)
         self.message = message
         self.size = size
-        if int(math.ceil(len(message) * 1.0 / self.size)) > 128:
-            warnings.warn("GELF chunk overflow for message: {}".format(message), RuntimeWarning)
-            self.message = self.on_chunk_overflow(message)
+        if int(math.ceil(len(self.message) * 1.0 / self.size)) > 128:
+            warnings.warn("GELF chunk overflow for message: {}".format(self.message), RuntimeWarning)
+            self.message = self.on_chunk_overflow(self.message)
         self.pieces = \
-            struct.pack('B', int(math.ceil(len(self.message) * 1.0 / size)))
+            struct.pack('B', int(math.ceil(len(self.message) * 1.0 / self.size)))
         self.id = struct.pack('Q', random.randint(0, 0xFFFFFFFFFFFFFFFF))
 
     def on_chunk_overflow(self, raw_message):

--- a/graypy/handler.py
+++ b/graypy/handler.py
@@ -274,7 +274,6 @@ class BaseGELFHandler(logging.Handler, ABC):
             from to insert into the given ``gelf_dict``.
         :type record: logging.LogRecord
         """
-
         # skip_list is used to filter additional fields in a log message.
         skip_list = (
             'args', 'asctime', 'created', 'exc_info', 'exc_text', 'filename',
@@ -351,6 +350,11 @@ class GELFChunkOverflowWarning(Warning):
 
 class GELFChunker(object):
     def __init__(self, chunk_size=WAN_CHUNK):
+        """
+
+        :param chunk_size:
+        :type chunk_size: int
+        """
         self.chunk_size = chunk_size
 
     def get_message_chunk_number(self, message):
@@ -550,7 +554,6 @@ class GELFTLSHandler(GELFTCPHandler):
             stored with the certificate, this parameter can be ignored.
         :type keyfile: str
         """
-
         if validate and ca_certs is None:
             raise ValueError('CA bundle file path must be specified')
 
@@ -609,7 +612,6 @@ class GELFHTTPHandler(BaseGELFHandler):
             it discards the request if the Graylog server doesn't respond.
         :type timeout: int
         """
-
         BaseGELFHandler.__init__(self, compress=compress, **kwargs)
 
         self.host = host

--- a/graypy/handler.py
+++ b/graypy/handler.py
@@ -489,7 +489,7 @@ class GELFTruncatingChunker(BaseGELFChunker):
             else:
                 truncated_short_message = truncated_short_message[:-self.chunk_size]
         else:
-            raise ValueError("Failed to prevent chunk overflowing with truncation")
+            raise ValueError("Failed to prevent chunk overflowing with truncation for message: {}".format(raw_message))
 
     def chunk_message(self, message):
         if self.get_message_chunk_number(message) > GELF_MAX_CHUNK_NUMBER:
@@ -497,8 +497,7 @@ class GELFTruncatingChunker(BaseGELFChunker):
             try:
                 message = self.gen_chunk_overflow_gelf_log(message)
             except (zlib.error, ValueError):
-                warnings.warn(
-                    "Failed to truncate GELF chunk overflowing message: {}".format(message), GELFChunkOverflowWarning)
+                warnings.warn("Failed truncating GELF chunk overflowing message: {}".format(traceback.format_exc()), GELFChunkOverflowWarning)
                 return
         for chunk in self._gen_gelf_chunks(message):
             yield chunk

--- a/graypy/handler.py
+++ b/graypy/handler.py
@@ -431,7 +431,8 @@ class GELFTruncatingChunker(GELFChunker):
 
         glef_message = json.loads(message.decode("UTF-8"))
 
-        short_message = b"GELF_CHUNK_OVERFLOW:" + glef_message['short_message']
+        short_message = glef_message['short_message']
+
         while True:
             gelf_dict = {
                 'version': glef_message['version'],

--- a/graypy/handler.py
+++ b/graypy/handler.py
@@ -345,7 +345,7 @@ class BaseGELFHandler(logging.Handler, ABC):
         return repr(obj)
 
 
-class GLEFChunkOverflowWarning(Warning):
+class GELFChunkOverflowWarning(Warning):
     pass
 
 
@@ -393,13 +393,13 @@ class GELFChunker(object):
 
     def iter_gelf_chunks(self, message):
         if self.get_message_chunk_number(message) > 128:
-            warnings.warn("GELF chunk overflow for message: {}".format(message), GLEFChunkOverflowWarning)
+            warnings.warn("GELF chunk overflow for message: {}".format(message), GELFChunkOverflowWarning)
             return
         for chunk in self.gen_gelf_chunks(message):
             yield chunk
 
 
-class GELFTruncatingChunder(GELFChunker):
+class GELFTruncatingChunker(GELFChunker):
     def __init__(self, chunk_size=WAN_CHUNK, gelf_packer=BaseGELFHandler._pack_gelf_dict):
         GELFChunker.__init__(self, chunk_size)
         self.gelf_packer = gelf_packer
@@ -447,14 +447,14 @@ class GELFTruncatingChunder(GELFChunker):
                 short_message = short_message[:-1]
             if not short_message:
                 warnings.warn(
-                    "Failed to handle GELF chunk overflow for message: {}".format(
-                        raw_message), GLEFChunkOverflowWarning)
+                    "Failed to truncate GELF chunk overflow for message: {}".format(
+                        raw_message), GELFChunkOverflowWarning)
                 return raw_message
 
     def iter_gelf_chunks(self, message):
         if self.get_message_chunk_number(message) > 128:
-            warnings.warn("GELF chunk overflow for message: {}".format(message), GLEFChunkOverflowWarning)
-            return
+            warnings.warn("GELF chunk overflow for message: {}".format(message), GELFChunkOverflowWarning)
+            message = self.gen_chunk_overflow_gelf_log(message)
         for chunk in self.gen_gelf_chunks(message):
             yield chunk
 

--- a/graypy/handler.py
+++ b/graypy/handler.py
@@ -408,7 +408,7 @@ class GELFWarningChunker(BaseGELFChunker):
 
     def chunk_message(self, message):
         if self.get_message_chunk_number(message) > GELF_MAX_CHUNK_NUMBER:
-            warnings.warn("GELF chunk overflow for message: {}".format(message), GELFChunkOverflowWarning)
+            warnings.warn("GELF chunk overflowing message: {}".format(message), GELFChunkOverflowWarning)
             return
         for chunk in self._gen_gelf_chunks(message):
             yield chunk
@@ -493,12 +493,12 @@ class GELFTruncatingChunker(BaseGELFChunker):
 
     def chunk_message(self, message):
         if self.get_message_chunk_number(message) > GELF_MAX_CHUNK_NUMBER:
-            warnings.warn("GELF chunk overflow for message: {}".format(message), GELFChunkOverflowWarning)
+            warnings.warn("Truncating GELF chunk overflowing message: {}".format(message), GELFChunkOverflowWarning)
             try:
                 message = self.gen_chunk_overflow_gelf_log(message)
             except (zlib.error, ValueError):
                 warnings.warn(
-                    "Failed to truncate GELF chunk overflow for message: {}".format(message), GELFChunkOverflowWarning)
+                    "Failed to truncate GELF chunk overflowing message: {}".format(message), GELFChunkOverflowWarning)
                 return
         for chunk in self._gen_gelf_chunks(message):
             yield chunk

--- a/graypy/handler.py
+++ b/graypy/handler.py
@@ -468,7 +468,7 @@ class GELFTruncatingChunker(BaseGELFChunker):
         # used to estimate the amount of truncation to apply
         gelf_chunks_free = GELF_MAX_CHUNK_NUMBER - self.get_message_chunk_number(zlib.compress(self.gelf_packer(simplified_gelf_dict)) if self.compress else self.gelf_packer(simplified_gelf_dict))
         truncated_short_message = gelf_dict['short_message'][:self.chunk_size * gelf_chunks_free]
-        for clip in range(gelf_chunks_free, 0, -1):
+        for clip in range(gelf_chunks_free, -1, -1):
             simplified_gelf_dict['short_message'] = truncated_short_message
             packed_message = self.gelf_packer(simplified_gelf_dict)
             if self.compress:

--- a/graypy/rabbitmq.py
+++ b/graypy/rabbitmq.py
@@ -68,10 +68,7 @@ class GELFRabbitHandler(BaseGELFHandler, SocketHandler):
         self.exchange = exchange
         self.exchange_type = exchange_type
         self.routing_key = routing_key
-        BaseGELFHandler.__init__(
-            self,
-            **kwargs
-        )
+        BaseGELFHandler.__init__(self, **kwargs)
         SocketHandler.__init__(self, host, port)
         self.addFilter(ExcludeFilter('amqplib'))
 

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -33,10 +33,10 @@ TEST_TLS_PORT = 12204
     GELFHTTPHandler('127.0.0.1', TEST_HTTP_PORT, compress=False),
     GELFUDPHandler("127.0.0.1", TEST_UDP_PORT),
     GELFUDPHandler("127.0.0.1", TEST_UDP_PORT, compress=False),
-    GELFUDPHandler("127.0.0.1", TEST_UDP_PORT, extra_fields=True),
-    GELFUDPHandler("127.0.0.1", TEST_UDP_PORT, extra_fields=True, compress=False),
-    GELFUDPHandler("127.0.0.1", TEST_UDP_PORT, extra_fields=True, debugging_fields=True),
-    GELFUDPHandler("127.0.0.1", TEST_UDP_PORT, extra_fields=True, debugging_fields=True, compress=False),
+    # the below handler tests are essentially smoke tests
+    # that help cover the argument permutations of BaseGELFHandler
+    GELFUDPHandler("127.0.0.1", TEST_UDP_PORT, debugging_fields=True, extra_fields=True, localname="foobar_localname", facility="foobar_facility", level_names=True, compress=False),
+    GELFUDPHandler("127.0.0.1", TEST_UDP_PORT, debugging_fields=True, extra_fields=True, fqdn=True, facility="foobar_facility", level_names=True, compress=False),
 ])
 def handler(request):
     return request.param

--- a/tests/integration/helper.py
+++ b/tests/integration/helper.py
@@ -18,15 +18,23 @@ DEFAULT_FIELDS = [
     "func", "file", "line", "module", "logger_name",
 ]
 
-BASE_API_URL = 'http://127.0.0.1:9000/api/search/universal/relative?query=message:"{0}"&range=5&fields='
+BASE_API_URL = 'http://127.0.0.1:9000/api/search/universal/relative?query=message:"{0}"&range=300&fields='
 
 
 def get_graylog_response(message, fields=None):
     """Search for a given log message (with possible additional fields)
     within a local Graylog instance"""
     fields = fields if fields else []
-    api_resp = _get_api_response(message, fields)
-    return _parse_api_response(api_resp)
+    tries = 0
+
+    while True:
+        try:
+            return _parse_api_response(_get_api_response(message, fields))
+        except AssertionError:
+            sleep(2)
+            if tries == 5:
+                raise
+            tries += 1
 
 
 def _build_api_string(message, fields):
@@ -34,7 +42,6 @@ def _build_api_string(message, fields):
 
 
 def _get_api_response(message, fields):
-    sleep(2)
     url = _build_api_string(message, fields)
     api_response = requests.get(
         url,

--- a/tests/integration/helper.py
+++ b/tests/integration/helper.py
@@ -58,6 +58,6 @@ def _parse_api_response(api_response, wanted_message):
     assert api_response.status_code == 200
     print(api_response.json())
     for message in api_response.json()["messages"]:
-        if message["message"] == wanted_message:
-            return message
+        if message["message"]["message"] == wanted_message:
+            return message["message"]
     raise ValueError("wanted_message: '{}' not within api_response: {}".format(wanted_message, api_response))

--- a/tests/integration/test_chunked_logging.py
+++ b/tests/integration/test_chunked_logging.py
@@ -7,19 +7,28 @@ import logging
 
 import pytest
 
-from graypy.handler import SYSLOG_LEVELS, GELFUDPHandler, GELFWarningChunker
+from graypy.handler import SYSLOG_LEVELS, GELFUDPHandler, GELFWarningChunker, \
+    BaseGELFChunker, GELFTruncatingChunker
 
 from tests.helper import TEST_UDP_PORT
 from tests.integration import LOCAL_GRAYLOG_UP
 from tests.integration.helper import get_unique_message, get_graylog_response
 
 
+@pytest.mark.parametrize(
+    "gelf_chunker",
+    [
+        BaseGELFChunker,
+        GELFWarningChunker,
+        GELFTruncatingChunker
+    ]
+)
 @pytest.mark.skipif(not LOCAL_GRAYLOG_UP,
                     reason="local Graylog instance not up")
-def test_chunked_logging():
+def test_chunked_logging(gelf_chunker):
     """Test sending a log that requires chunking to be fully sent"""
     logger = logging.getLogger("test_chunked_logger")
-    handler = GELFUDPHandler("127.0.0.1", TEST_UDP_PORT, gelf_chunker=GELFWarningChunker(10))
+    handler = GELFUDPHandler("127.0.0.1", TEST_UDP_PORT, gelf_chunker=gelf_chunker(chunk_size=10))
     logger.addHandler(handler)
     message = get_unique_message()
     logger.error(message)

--- a/tests/integration/test_chunked_logging.py
+++ b/tests/integration/test_chunked_logging.py
@@ -7,7 +7,7 @@ import logging
 
 import pytest
 
-from graypy.handler import SYSLOG_LEVELS, GELFUDPHandler
+from graypy.handler import SYSLOG_LEVELS, GELFUDPHandler, GELFChunker
 
 from tests.helper import TEST_UDP_PORT
 from tests.integration import LOCAL_GRAYLOG_UP
@@ -19,7 +19,7 @@ from tests.integration.helper import get_unique_message, get_graylog_response
 def test_chunked_logging():
     """Test sending a log that requires chunking to be fully sent"""
     logger = logging.getLogger("test_chunked_logger")
-    handler = GELFUDPHandler("127.0.0.1", TEST_UDP_PORT, chunk_size=10)
+    handler = GELFUDPHandler("127.0.0.1", TEST_UDP_PORT, chunk_size=GELFChunker(10))
     logger.addHandler(handler)
     message = get_unique_message()
     logger.error(message)

--- a/tests/integration/test_chunked_logging.py
+++ b/tests/integration/test_chunked_logging.py
@@ -7,7 +7,7 @@ import logging
 
 import pytest
 
-from graypy.handler import SYSLOG_LEVELS, GELFUDPHandler, GELFChunker
+from graypy.handler import SYSLOG_LEVELS, GELFUDPHandler, GELFWarningChunker
 
 from tests.helper import TEST_UDP_PORT
 from tests.integration import LOCAL_GRAYLOG_UP
@@ -19,7 +19,7 @@ from tests.integration.helper import get_unique_message, get_graylog_response
 def test_chunked_logging():
     """Test sending a log that requires chunking to be fully sent"""
     logger = logging.getLogger("test_chunked_logger")
-    handler = GELFUDPHandler("127.0.0.1", TEST_UDP_PORT, gelf_chunker=GELFChunker(10))
+    handler = GELFUDPHandler("127.0.0.1", TEST_UDP_PORT, gelf_chunker=GELFWarningChunker(10))
     logger.addHandler(handler)
     message = get_unique_message()
     logger.error(message)

--- a/tests/integration/test_chunked_logging.py
+++ b/tests/integration/test_chunked_logging.py
@@ -19,7 +19,7 @@ from tests.integration.helper import get_unique_message, get_graylog_response
 def test_chunked_logging():
     """Test sending a log that requires chunking to be fully sent"""
     logger = logging.getLogger("test_chunked_logger")
-    handler = GELFUDPHandler("127.0.0.1", TEST_UDP_PORT, chunk_size=GELFChunker(10))
+    handler = GELFUDPHandler("127.0.0.1", TEST_UDP_PORT, gelf_chunker=GELFChunker(10))
     logger.addHandler(handler)
     message = get_unique_message()
     logger.error(message)

--- a/tests/unit/test_chunking.py
+++ b/tests/unit/test_chunking.py
@@ -46,11 +46,12 @@ def test_gelf_chunking(gelf_chunker):
 
 def rebuild_gelf_bytes_from_udp_chunks(chunks):
     gelf_bytes = b""
+    bsize = len(chunks[0])
     for chunk in chunks:
-        stripped_chunk = b"".join(chunk.split(b'\x1e\x0f')[1:])
-        message_id, chunk_seq, total_chunks = struct.unpack_from('QBB', stripped_chunk)
-        chunk = stripped_chunk[struct.calcsize('QBB'):]
-        gelf_bytes += chunk
+        if len(chunk) < bsize:
+            gelf_bytes += chunk[-(bsize-len(chunk)):]
+        else:
+            gelf_bytes += chunk[((2+struct.calcsize("QBB"))-len(chunk)):]
     return gelf_bytes
 
 

--- a/tests/unit/test_chunking.py
+++ b/tests/unit/test_chunking.py
@@ -118,5 +118,5 @@ def test_chunk_overflow_truncate_fail():
         logging.LogRecord("test_chunk_overflow_truncate_fail", logging.INFO,
                           None, None, "1"*128, None, None))
     with pytest.warns(GELFChunkOverflowWarning,
-                      match="Failed to truncate GELF chunk overflowing message: .*$"):
+                      match="Failed to truncate GELF chunk overflowing message: .*"):
         list(GELFTruncatingChunker(1).chunk_message(message))

--- a/tests/unit/test_chunking.py
+++ b/tests/unit/test_chunking.py
@@ -117,5 +117,6 @@ def test_chunk_overflow_truncate_fail():
     message = BaseGELFHandler().makePickle(
         logging.LogRecord("test_chunk_overflow_truncate_fail", logging.INFO,
                           None, None, "1"*128, None, None))
-    with pytest.warns(GELFChunkOverflowWarning):
-        list(GELFWarningChunker(1).chunk_message(message))
+    with pytest.warns(GELFChunkOverflowWarning,
+                      match="Failed to truncate GELF chunk overflowing message: .*$"):
+        list(GELFTruncatingChunker(1).chunk_message(message))

--- a/tests/unit/test_chunking.py
+++ b/tests/unit/test_chunking.py
@@ -82,7 +82,7 @@ def test_gelf_chunkers_overflow(gelf_chunker):
     message = BaseGELFHandler().makePickle(
         logging.LogRecord("test_gelf_chunkers_overflow", logging.INFO,
                           None, None, "1" * 1000, None, None))
-    chunks = list(gelf_chunker(chunk_size=2).chunk_message(message))
+    chunks = list(gelf_chunker(chunk_size=1).chunk_message(message))
     assert len(chunks) <= 128
 
 
@@ -118,6 +118,5 @@ def test_chunk_overflow_truncate_fail():
     message = BaseGELFHandler().makePickle(
         logging.LogRecord("test_chunk_overflow_truncate_fail", logging.INFO,
                           None, None, "1"*128, None, None))
-    with pytest.warns(GELFTruncationFailureWarning,
-                      match="Failed truncating GELF chunk overflowing message: .*"):
+    with pytest.warns(GELFTruncationFailureWarning):
         list(GELFTruncatingChunker(1).chunk_message(message))

--- a/tests/unit/test_chunking.py
+++ b/tests/unit/test_chunking.py
@@ -11,7 +11,8 @@ import zlib
 import pytest
 
 from graypy.handler import GELFTruncatingChunker, GELFWarningChunker, \
-    BaseGELFChunker, BaseGELFHandler, SYSLOG_LEVELS, GELFChunkOverflowWarning
+    BaseGELFChunker, BaseGELFHandler, SYSLOG_LEVELS, GELFChunkOverflowWarning, \
+    GELFTruncationFailureWarning
 
 
 @pytest.mark.parametrize(
@@ -117,6 +118,6 @@ def test_chunk_overflow_truncate_fail():
     message = BaseGELFHandler().makePickle(
         logging.LogRecord("test_chunk_overflow_truncate_fail", logging.INFO,
                           None, None, "1"*128, None, None))
-    with pytest.warns(GELFChunkOverflowWarning,
+    with pytest.warns(GELFTruncationFailureWarning,
                       match="Failed truncating GELF chunk overflowing message: .*"):
         list(GELFTruncatingChunker(1).chunk_message(message))

--- a/tests/unit/test_chunking.py
+++ b/tests/unit/test_chunking.py
@@ -23,8 +23,7 @@ from graypy.handler import GELFTruncatingChunker, GELFWarningChunker, \
     ]
 )
 def test_gelf_chunking(gelf_chunker):
-    """Testing the GELF chunking ability of
-    :class:`graypy.handler.GELFWarningChunker`"""
+    """Test various GELF chunkers"""
     message = b'12345'
     header = b'\x1e\x0f'
     chunks = list(gelf_chunker(chunk_size=2).chunk_message(message))

--- a/tests/unit/test_chunking.py
+++ b/tests/unit/test_chunking.py
@@ -118,5 +118,5 @@ def test_chunk_overflow_truncate_fail():
         logging.LogRecord("test_chunk_overflow_truncate_fail", logging.INFO,
                           None, None, "1"*128, None, None))
     with pytest.warns(GELFChunkOverflowWarning,
-                      match="Failed to truncate GELF chunk overflowing message: .*"):
+                      match="Failed truncating GELF chunk overflowing message: .*"):
         list(GELFTruncatingChunker(1).chunk_message(message))

--- a/tests/unit/test_chunking.py
+++ b/tests/unit/test_chunking.py
@@ -89,34 +89,34 @@ def test_gelf_chunkers_overflow(gelf_chunker):
 def test_chunk_overflow_truncate_uncompressed():
     message = BaseGELFHandler(compress=False).makePickle(
         logging.LogRecord("test_chunk_overflow_truncate_uncompressed",
-                          logging.INFO, None, None, "1"*1000, None, None))
+                          logging.INFO, None, None, "1" * 1000, None, None))
     with pytest.warns(GELFChunkOverflowWarning):
         chunks = list(GELFTruncatingChunker(chunk_size=2, compress=False).chunk_message(message))
     assert len(chunks) <= 128
     payload = rebuild_gelf_bytes_from_udp_chunks(chunks).decode("UTF-8")
     glef_json = json.loads(payload)
     assert glef_json["_chunk_overflow"] is True
-    assert glef_json["short_message"] in "1"*1000
+    assert glef_json["short_message"] in "1" * 1000
     assert glef_json["level"] == SYSLOG_LEVELS.get(logging.ERROR, logging.ERROR)
 
 
 def test_chunk_overflow_truncate_compressed():
     message = BaseGELFHandler(compress=True).makePickle(
         logging.LogRecord("test_chunk_overflow_truncate_compressed",
-                          logging.INFO, None, None, "123412345"*5000, None, None))
+                          logging.INFO, None, None, "123412345" * 5000, None, None))
     with pytest.warns(GELFChunkOverflowWarning):
         chunks = list(GELFTruncatingChunker(chunk_size=2, compress=True).chunk_message(message))
     assert len(chunks) <= 128
     payload = zlib.decompress(rebuild_gelf_bytes_from_udp_chunks(chunks)).decode("UTF-8")
     glef_json = json.loads(payload)
     assert glef_json["_chunk_overflow"] is True
-    assert glef_json["short_message"] in "123412345"*5000
+    assert glef_json["short_message"] in "123412345" * 5000
     assert glef_json["level"] == SYSLOG_LEVELS.get(logging.ERROR, logging.ERROR)
 
 
 def test_chunk_overflow_truncate_fail():
     message = BaseGELFHandler().makePickle(
         logging.LogRecord("test_chunk_overflow_truncate_fail", logging.INFO,
-                          None, None, "1"*128, None, None))
+                          None, None, "1" * 1000, None, None))
     with pytest.warns(GELFTruncationFailureWarning):
         list(GELFTruncatingChunker(1).chunk_message(message))

--- a/tests/unit/test_chunking.py
+++ b/tests/unit/test_chunking.py
@@ -120,3 +120,10 @@ def test_chunk_overflow_truncate_fail():
                           None, None, "1" * 1000, None, None))
     with pytest.warns(GELFTruncationFailureWarning):
         list(GELFTruncatingChunker(1).chunk_message(message))
+
+
+def test_chunk_overflow_truncate_fail_large_inherited_field():
+    message = BaseGELFHandler(facility="this is a really long facility" * 5000)\
+        .makePickle(logging.LogRecord("test_chunk_overflow_truncate_fail", logging.INFO, None, None, "reasonable message", None, None))
+    with pytest.warns(GELFTruncationFailureWarning):
+        list(GELFTruncatingChunker(2).chunk_message(message))

--- a/tests/unit/test_chunking.py
+++ b/tests/unit/test_chunking.py
@@ -44,7 +44,13 @@ def test_gelf_chunking(gelf_chunker):
 
 
 def rebuild_gelf_bytes_from_udp_chunks(chunks):
-    return b"".join([chunk[-2:] for chunk in chunks])
+    gelf_bytes = b""
+    for chunk in chunks:
+        stripped_chunk = b"".join(chunk.split(b'\x1e\x0f')[1:])
+        message_id, chunk_seq, total_chunks = struct.unpack_from('QBB', stripped_chunk)
+        chunk = stripped_chunk[struct.calcsize('QBB'):]
+        gelf_bytes += chunk
+    return gelf_bytes
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_chunking.py
+++ b/tests/unit/test_chunking.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""pytests for various GELF UDP message chunkers"""
+
+import json
+import logging
+import struct
+import zlib
+
+import pytest
+
+from graypy.handler import GELFTruncatingChunker, GELFWarningChunker, \
+    BaseGELFChunker, BaseGELFHandler, SYSLOG_LEVELS, GELFChunkOverflowWarning
+
+
+@pytest.mark.parametrize(
+    "gelf_chunker",
+    [
+        BaseGELFChunker,
+        GELFWarningChunker,
+        GELFTruncatingChunker
+    ]
+)
+def test_gelf_chunking(gelf_chunker):
+    """Testing the GELF chunking ability of
+    :class:`graypy.handler.GELFWarningChunker`"""
+    message = b'12345'
+    header = b'\x1e\x0f'
+    chunks = list(gelf_chunker(chunk_size=2).chunk_message(message))
+    expected = [
+        (struct.pack('b', 0), struct.pack('b', 3), b'12'),
+        (struct.pack('b', 1), struct.pack('b', 3), b'34'),
+        (struct.pack('b', 2), struct.pack('b', 3), b'5')
+    ]
+
+    assert len(chunks) == len(expected)
+
+    for index, chunk in enumerate(chunks):
+        expected_index, expected_chunks_count, expected_chunk = expected[index]
+        assert header == chunk[:2]
+        assert expected_index == chunk[10:11]
+        assert expected_chunks_count == chunk[11:12]
+        assert expected_chunk == chunk[12:]
+
+
+def rebuild_gelf_bytes_from_udp_chunks(chunks):
+    return b"".join([chunk[-2:] for chunk in chunks])
+
+
+@pytest.mark.parametrize(
+    "gelf_chunker",
+    [
+        BaseGELFChunker,
+        GELFWarningChunker,
+        GELFTruncatingChunker
+    ]
+)
+def test_gelf_chunkers(gelf_chunker):
+    message = BaseGELFHandler().makePickle(
+        logging.LogRecord("test_gelf_chunkers", logging.INFO,
+                          None, None, "1" * 10, None, None))
+    chunks = list(gelf_chunker(chunk_size=2).chunk_message(message))
+    assert len(chunks) <= 128
+
+
+@pytest.mark.parametrize(
+    "gelf_chunker",
+    [
+        BaseGELFChunker,
+        GELFWarningChunker,
+        GELFTruncatingChunker
+    ]
+)
+def test_gelf_chunkers_overflow(gelf_chunker):
+    message = BaseGELFHandler().makePickle(
+        logging.LogRecord("test_gelf_chunkers_overflow", logging.INFO,
+                          None, None, "1" * 1000, None, None))
+    chunks = list(gelf_chunker(chunk_size=2).chunk_message(message))
+    assert len(chunks) <= 128
+
+
+def test_chunk_overflow_truncate_uncompressed():
+    message = BaseGELFHandler(compress=False).makePickle(
+        logging.LogRecord("test_chunk_overflow_truncate_uncompressed",
+                          logging.INFO, None, None, "1"*1000, None, None))
+    with pytest.warns(GELFChunkOverflowWarning):
+        chunks = list(GELFTruncatingChunker(chunk_size=2).chunk_message(message))
+    assert len(chunks) <= 128
+    payload = rebuild_gelf_bytes_from_udp_chunks(chunks).decode("UTF-8")
+    glef_json = json.loads(payload)
+    assert glef_json["_chunk_overflow"] is True
+    assert glef_json["short_message"] != "1"*1000
+    assert glef_json["level"] == SYSLOG_LEVELS.get(logging.ERROR, logging.ERROR)
+
+
+def test_chunk_overflow_truncate_compressed():
+    message = BaseGELFHandler(compress=True).makePickle(
+        logging.LogRecord("test_chunk_overflow_truncate_compressed",
+                          logging.INFO, None, None, "123412345"*5000, None, None))
+    with pytest.warns(GELFChunkOverflowWarning):
+        chunks = list(GELFTruncatingChunker(chunk_size=2).chunk_message(message))
+    assert len(chunks) <= 128
+    payload = zlib.decompress(rebuild_gelf_bytes_from_udp_chunks(chunks)).decode("UTF-8")
+    glef_json = json.loads(payload)
+    assert glef_json["_chunk_overflow"] is True
+    assert glef_json["short_message"] != "123412345"*5000
+    assert glef_json["level"] == SYSLOG_LEVELS.get(logging.ERROR, logging.ERROR)
+
+
+def test_chunk_overflow_truncate_fail():
+    message = BaseGELFHandler().makePickle(
+        logging.LogRecord("test_chunk_overflow_truncate_fail", logging.INFO,
+                          None, None, "1"*128, None, None))
+    with pytest.warns(GELFChunkOverflowWarning):
+        list(GELFWarningChunker(1).chunk_message(message))

--- a/tests/unit/test_chunking.py
+++ b/tests/unit/test_chunking.py
@@ -95,7 +95,7 @@ def test_chunk_overflow_truncate_uncompressed():
     payload = rebuild_gelf_bytes_from_udp_chunks(chunks).decode("UTF-8")
     glef_json = json.loads(payload)
     assert glef_json["_chunk_overflow"] is True
-    assert glef_json["short_message"] != "1"*1000
+    assert glef_json["short_message"] in "1"*1000
     assert glef_json["level"] == SYSLOG_LEVELS.get(logging.ERROR, logging.ERROR)
 
 
@@ -109,7 +109,7 @@ def test_chunk_overflow_truncate_compressed():
     payload = zlib.decompress(rebuild_gelf_bytes_from_udp_chunks(chunks)).decode("UTF-8")
     glef_json = json.loads(payload)
     assert glef_json["_chunk_overflow"] is True
-    assert glef_json["short_message"] != "123412345"*5000
+    assert glef_json["short_message"] in "123412345"*5000
     assert glef_json["level"] == SYSLOG_LEVELS.get(logging.ERROR, logging.ERROR)
 
 

--- a/tests/unit/test_chunking.py
+++ b/tests/unit/test_chunking.py
@@ -90,7 +90,7 @@ def test_chunk_overflow_truncate_uncompressed():
         logging.LogRecord("test_chunk_overflow_truncate_uncompressed",
                           logging.INFO, None, None, "1"*1000, None, None))
     with pytest.warns(GELFChunkOverflowWarning):
-        chunks = list(GELFTruncatingChunker(chunk_size=2).chunk_message(message))
+        chunks = list(GELFTruncatingChunker(chunk_size=2, compress=False).chunk_message(message))
     assert len(chunks) <= 128
     payload = rebuild_gelf_bytes_from_udp_chunks(chunks).decode("UTF-8")
     glef_json = json.loads(payload)
@@ -104,7 +104,7 @@ def test_chunk_overflow_truncate_compressed():
         logging.LogRecord("test_chunk_overflow_truncate_compressed",
                           logging.INFO, None, None, "123412345"*5000, None, None))
     with pytest.warns(GELFChunkOverflowWarning):
-        chunks = list(GELFTruncatingChunker(chunk_size=2).chunk_message(message))
+        chunks = list(GELFTruncatingChunker(chunk_size=2, compress=True).chunk_message(message))
     assert len(chunks) <= 128
     payload = zlib.decompress(rebuild_gelf_bytes_from_udp_chunks(chunks)).decode("UTF-8")
     glef_json = json.loads(payload)

--- a/tests/unit/test_handler.py
+++ b/tests/unit/test_handler.py
@@ -226,7 +226,7 @@ def test_gelf_chunking():
     :class:`graypy.handler.ChunkedGELF`"""
     message = b'12345'
     header = b'\x1e\x0f'
-    chunks = list(GELFUDPHandler(message, 2).__iter__())
+    chunks = list(GELFChunker(2).iter_gelf_chunks(message))
     expected = [
         (struct.pack('b', 0), struct.pack('b', 3), b'12'),
         (struct.pack('b', 1), struct.pack('b', 3), b'34'),

--- a/tests/unit/test_handler.py
+++ b/tests/unit/test_handler.py
@@ -256,7 +256,6 @@ def test_chunk_overflow_uncompressed():
     glef_json = json.loads(payload)
     assert glef_json["_chunk_overflow"] is True
     assert glef_json["short_message"] != "1"*1000
-    assert b'GELF_CHUNK_OVERFLOW:' in glef_json["short_message"]
     assert glef_json["level"] == SYSLOG_LEVELS.get(logging.ERROR, logging.ERROR)
 
 
@@ -272,7 +271,6 @@ def test_chunk_overflow_compressed():
     glef_json = json.loads(payload)
     assert glef_json["_chunk_overflow"] is True
     assert glef_json["short_message"] != "123412345"*5000
-    assert b'GELF_CHUNK_OVERFLOW:' in glef_json["short_message"]
     assert glef_json["level"] == SYSLOG_LEVELS.get(logging.ERROR, logging.ERROR)
 
 

--- a/tests/unit/test_handler.py
+++ b/tests/unit/test_handler.py
@@ -22,7 +22,7 @@ import mock
 import pytest
 
 from graypy.handler import BaseGELFHandler, GELFHTTPHandler, GELFTLSHandler, \
-    SYSLOG_LEVELS, GELFUDPHandler, GELFChunker, GELFTruncatingChunker, \
+    SYSLOG_LEVELS, GELFUDPHandler, GELFWarningChunker, GELFTruncatingChunker, \
     GELFChunkOverflowWarning
 
 from tests.helper import handler, logger, formatted_logger
@@ -224,10 +224,10 @@ def test_invalid_client_certs():
 
 def test_gelf_chunking():
     """Testing the GELF chunking ability of
-    :class:`graypy.handler.GELFChunker`"""
+    :class:`graypy.handler.GELFWarningChunker`"""
     message = b'12345'
     header = b'\x1e\x0f'
-    chunks = list(GELFChunker(2).iter_gelf_chunks(message))
+    chunks = list(GELFWarningChunker(2).iter_gelf_chunks(message))
     expected = [
         (struct.pack('b', 0), struct.pack('b', 3), b'12'),
         (struct.pack('b', 1), struct.pack('b', 3), b'34'),
@@ -277,4 +277,4 @@ def test_chunk_overflow_compressed():
 def test_chunk_overflow_fail():
     message = BaseGELFHandler().makePickle(logging.LogRecord("test_chunk_overflow_fail", logging.INFO, None, None, "1"*128, None, None))
     with pytest.warns(GELFChunkOverflowWarning):
-        list(GELFChunker(1).iter_gelf_chunks(message))
+        list(GELFWarningChunker(1).iter_gelf_chunks(message))

--- a/tests/unit/test_handler.py
+++ b/tests/unit/test_handler.py
@@ -223,7 +223,7 @@ def test_invalid_client_certs():
 
 def test_gelf_chunking():
     """Testing the GELF chunking ability of
-    :class:`graypy.handler.ChunkedGELF`"""
+    :class:`graypy.handler.GELFChunker`"""
     message = b'12345'
     header = b'\x1e\x0f'
     chunks = list(GELFChunker(2).iter_gelf_chunks(message))


### PR DESCRIPTION
Resolves the issues present with the `GELFUDPHandler` not properly dealing with the case of a chunked GELF message overflowing.

Adds three GELF chunker classes each having different behavior on a GELF chunk overflow on a message:

* `BaseGELFChunker` silently drops GELF messages that chunk overflow
* `GELFWarningChunker` notes a python `Warning` and drops GELF messages that chunk overflow
* `GELFTruncatingChunker` notes a python `Warning` and simplifies and truncates a chunk overflowing GELF message in a attempt sending to at least send some content to Graylog

Additionally, users can subclass `BaseGELFChunker` to implement custom handling of chunk overflowing GELF messages.

**Other features:**
* Misc refactoring
* Improvement on instrumentation testing stability
* Documentation improvements

resolves #116 
resolves #112 