### PR TITLE
Replace yield_fixture() by fixture()

### DIFF
--- a/tests/helper.py
+++ b/tests/helper.py
@@ -63,7 +63,7 @@ def handler(request):
     return request.param
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def logger(handler):
     logger_ = logging.getLogger("test_logger")
     logger_.addHandler(handler)
@@ -71,7 +71,7 @@ def logger(handler):
     logger_.removeHandler(handler)
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def formatted_logger(handler):
     logger_ = logging.getLogger("formatted_test_logger")
     handler.setFormatter(logging.Formatter("%(levelname)s : %(message)s"))

--- a/tests/integration/test_extra_fields.py
+++ b/tests/integration/test_extra_fields.py
@@ -47,7 +47,7 @@ def handler(request):
     return request.param
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def logger(handler):
     logger = logging.getLogger("test")
     dummy_filter = DummyFilter()

--- a/tests/unit/test_handler.py
+++ b/tests/unit/test_handler.py
@@ -33,7 +33,7 @@ class TestClass(object):
         return "<TestClass>"
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def mock_send(handler):
     try:
         with mock.patch.object(handler, "send") as mock_send:


### PR DESCRIPTION
`@pytest.yield_fixture` is deprecated since `pytest-3.0`, see:
https://docs.pytest.org/en/latest/yieldfixture.html