### PR TITLE
Added SSL/TLS support to GELFRabbitHandler

### DIFF
--- a/graypy/rabbitmq.py
+++ b/graypy/rabbitmq.py
@@ -59,8 +59,8 @@ class GELFRabbitHandler(BaseGELFHandler, SocketHandler):
         """
         self.url = url
         parsed = urlparse(url)
-        if parsed.scheme != "amqp":
-            raise ValueError('invalid URL scheme (expected "amqp"): %s' % url)
+        if parsed.scheme not in ("amqp", "amqps"):
+            raise ValueError('invalid URL scheme (expected "amqp" or "amqps"): %s' % url)
         host = parsed.hostname or "localhost"
         port = _ifnone(parsed.port, 5672)
         self.virtual_host = (
@@ -72,6 +72,7 @@ class GELFRabbitHandler(BaseGELFHandler, SocketHandler):
             "password": _ifnone(parsed.password, "guest"),
             "virtual_host": self.virtual_host,
             "insist": False,
+            "ssl": True if parsed.scheme == "amqps" else False
         }
         self.exchange = exchange
         self.exchange_type = exchange_type

--- a/tests/unit/test_GELFRabbitHandler.py
+++ b/tests/unit/test_GELFRabbitHandler.py
@@ -28,6 +28,15 @@ def test_valid_url():
     assert "amqp://localhost" == handler.url
 
 
+def test_valid_ssl_url():
+    """Test constructing :class:`graypy.rabbitmq.GELFRabbitHandler` with
+    a valid ssl rabbitmq url"""
+    handler = GELFRabbitHandler("amqps://localhost")
+    assert handler
+    assert "amqps://localhost" == handler.url
+    assert handler.cn_args["ssl"]
+
+
 @pytest.mark.xfail(reason="rabbitmq service is not up")
 def test_socket_creation_failure():
     """Test attempting to open a socket to a rabbitmq instance when no such


### PR DESCRIPTION
Noticed that there was no support for shipping to a RabbitMQ server that only had encrypted connections. These changes enable connections to TLS-enabled servers, however it doesn't support client certificates as this would require upstream modifications to amqplib.