### PR TITLE
Updated GELFUDPHandler to not make a DNS query for every log message.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -110,6 +110,19 @@ Other ``gelf_chunker`` options are also available:
   to send some content to Graylog. If this process fails to prevent
   another chunk overflow a ``GELFTruncationFailureWarning`` is issued.
 
+DNS Caching
+^^^^^^^^^^^^
+
+``GELFUDPHandler`` reuses the same socket to minimize DNS lookups (if required
+to resolve the provided host) and system resources. It will re-resolve
+every 5 minutes by default but you can override this using the ``sock_max_age``
+argument:
+
+.. code-block:: python
+
+    handler = graypy.GELFUDPHandler('example.com', 12201, sock_max_age=3600) # 1 hour
+
+
 RabbitMQ Logging
 ----------------
 


### PR DESCRIPTION
I ran into performance issues in prod because I'm using GELFUDPHandler with a host that requires a DNS lookup (our graylog server is available at something like `monitoring.prod.example.com`). This resulted in a DNS lookup for every single log message because the CPython DatagramHandler uses `socket.sendto()` like this: `self.sock.sendto(s, self.address)`: https://github.com/python/cpython/blob/main/Lib/logging/handlers.py#L732

The production-impacting issue we had was overwhelming our internal DNS server with too much traffic which slowed down logging and brought our web services to a crawl. Even for a healthy DNS server, the time to do a DNS lookup per log message is non-zero and worth saving, particularly for apps that do a lot of logging.


This Pull Request updates GELFUDPHandler to connect the socket to the address ahead of time using `socket.connect()` and then send the data using `socket.sendall()`. Using wireshark, I've tested that the DNS lookup occurs during `connect()` and not `sendall()`. I've also been running this algorithm in production for months and seen the expected drop in traffic to the DNS server.

To handle DNS changes, the code does make a new socket periodically and there's a `sock_max_age` parameter to control how often (I've set this to 1 hour in prod but figured 5 minutes was a more reasonable default in the library here).