### PR TITLE
Bugfix/graypy polluting site packages

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
 include LICENSE
 include README.rst
-recursive-include tests *.py
-recursive-include tests/config *
+recursive-exclude tests *

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
     author_email="banesiu.sever@gmail.com",
     url="https://github.com/severb/graypy",
     license="BSD License",
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests"]),
     include_package_data=True,
     zip_safe=False,
     tests_require=[

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
     author_email="banesiu.sever@gmail.com",
     url="https://github.com/severb/graypy",
     license="BSD License",
-    packages=find_packages(exclude=["tests"]),
+    packages=find_packages(exclude=["tests", "tests.*"]),
     include_package_data=True,
     zip_safe=False,
     tests_require=[


### PR DESCRIPTION
Resolves https://github.com/severb/graypy/issues/131

Fixes issue where installing graypy would also copy the project's `tests` directory to the Python environment's site-packages.