### PR TITLE
Bugfix/replace dependency amqplib with amqp

### DIFF
--- a/graypy/rabbitmq.py
+++ b/graypy/rabbitmq.py
@@ -8,7 +8,7 @@ import json
 from logging import Filter
 from logging.handlers import SocketHandler
 
-from amqplib import client_0_8 as amqp  # pylint: disable=import-error
+import amqp
 
 from graypy.handler import BaseGELFHandler
 
@@ -98,6 +98,7 @@ class RabbitSocket(object):
         self.exchange_type = exchange_type
         self.routing_key = routing_key
         self.connection = amqp.Connection(connection_timeout=timeout, **self.cn_args)
+        self.connection.connect()
         self.channel = self.connection.channel()
         self.channel.exchange_declare(
             exchange=self.exchange,

--- a/setup.py
+++ b/setup.py
@@ -80,10 +80,10 @@ setup(
         "pylint>=1.9.3,<2.0.0",
         "mock>=2.0.0,<3.0.0",
         "requests>=2.20.1,<3.0.0",
-        "amqplib>=1.0.2,<2.0.0",
+        "amqp>=5.1.1",
     ],
     extras_require={
-        "amqp": ["amqplib==1.0.2"],
+        "amqp": ["amqp==5.1.1"],
         "docs": [
             "sphinx>=2.1.2,<3.0.0",
             "sphinx_rtd_theme>=0.4.3,<1.0.0",


### PR DESCRIPTION
Resolves https://github.com/severb/graypy/issues/140.

Fixes issue where `graypy` fails to import the `client_0_8`  from `amqplib`.
See https://github.com/celery/py-amqp.